### PR TITLE
Add CA certificate to application gateway trusted root certificates

### DIFF
--- a/weblogic-azure-aks/pom.xml
+++ b/weblogic-azure-aks/pom.xml
@@ -11,7 +11,7 @@
 
   <groupId>com.oracle.weblogic.azure</groupId>
   <artifactId>wls-on-aks-azure-marketplace</artifactId>
-  <version>1.0.15</version>
+  <version>1.0.16</version>
 
   <parent>
     <groupId>com.microsoft.azure.iaas</groupId>

--- a/weblogic-azure-aks/src/main/arm/createUiDefinition.json
+++ b/weblogic-azure-aks/src/main/arm/createUiDefinition.json
@@ -1095,7 +1095,7 @@
                                 "type": "Microsoft.Common.TextBlock",
                                 "visible": "[steps('section_appGateway').appgwIngress.enableAppGateway]",
                                 "options": {
-                                    "text": "    ⁃ Generate a self-signed certificate: generate a self-signed certificate and apply it during deployment.",
+                                    "text": "    ⁃ Generate a self-signed frontend certificate: generate a self-signed frontend certificate and apply it during deployment.",
                                     "link": {
                                         "label": "Learn more",
                                         "uri": "https://aka.ms/arm-oraclelinux-wls-cluster-app-gateway-key-vault"
@@ -1106,7 +1106,7 @@
                                 "name": "certificateOption",
                                 "type": "Microsoft.Common.OptionsGroup",
                                 "label": "Select desired TLS/SSL certificate option",
-                                "defaultValue": "Generate a self-signed certificate",
+                                "defaultValue": "Upload a TLS/SSL certificate",
                                 "toolTip": "Select desired TLS/SSL certificate option",
                                 "constraints": {
                                     "allowedValues": [
@@ -1119,7 +1119,7 @@
                                             "value": "haveKeyVault"
                                         },
                                         {
-                                            "label": "Generate a self-signed certificate",
+                                            "label": "Generate a self-signed frontend certificate",
                                             "value": "generateCert"
                                         }
                                     ],
@@ -1130,7 +1130,7 @@
                             {
                                 "name": "keyVaultSSLCertData",
                                 "type": "Microsoft.Common.FileUpload",
-                                "label": "TLS/SSL certificate(.pfx)",
+                                "label": "Frontend TLS/SSL certificate(.pfx)",
                                 "toolTip": "TLS/SSL certificate used for App Gateway",
                                 "constraints": {
                                     "required": true,
@@ -1150,7 +1150,7 @@
                                     "password": "Password",
                                     "confirmPassword": "Confirm password"
                                 },
-                                "toolTip": "TLS/SSL certificate password",
+                                "toolTip": "Frontend TLS/SSL certificate password",
                                 "constraints": {
                                     "required": "[equals(steps('section_appGateway').appgwIngress.certificateOption, 'haveCert')]",
                                     "regex": "^((?=.*[0-9])(?=.*[a-z])|(?=.*[0-9])(?=.*[a-z])(?=.*[A-Z])|(?=.*[0-9])(?=.*[a-z])(?=.*[!@#$%^&*])|(?=.*[0-9])(?=.*[A-Z])(?=.*[!@#$%^&*])|(?=.*[a-z])(?=.*[A-Z])(?=.*[!@#$%^&*])).{6,128}$",
@@ -1160,6 +1160,22 @@
                                     "hideConfirmation": false
                                 },
                                 "visible": "[equals(steps('section_appGateway').appgwIngress.certificateOption, 'haveCert')]"
+                            },
+                            {
+                                "name": "keyVaultBackendSSLCertData",
+                                "type": "Microsoft.Common.FileUpload",
+                                "label": "Trusted root certificate(.cer, cert)",
+                                "toolTip": "Trusted root certificate (CA certificate) used to set up end to end TLS/SSL",
+                                "constraints": {
+                                    "required": true,
+                                    "accept": ".cer, cert"
+                                },
+                                "options": {
+                                    "multiple": false,
+                                    "uploadMode": "file",
+                                    "openMode": "binary"
+                                },
+                                "visible": "[and(steps('section_appGateway').appgwIngress.enableAppGateway, steps('section_sslConfiguration').enableCustomSSL, not(equals(steps('section_appGateway').appgwIngress.certificateOption, 'haveKeyVault')))]"
                             },
                             {
                                 "name": "keyVaultResourceGroup",
@@ -1190,7 +1206,7 @@
                             {
                                 "name": "keyVaultSSLCertDataSecretName",
                                 "type": "Microsoft.Common.TextBox",
-                                "label": "The name of the secret in the specified Key Vault whose value is the TLS/SSL certificate data",
+                                "label": "The name of the secret in the specified Key Vault whose value is the frontend TLS/SSL certificate data",
                                 "defaultValue": "",
                                 "toolTip": "Use only letters and numbers",
                                 "constraints": {
@@ -1203,7 +1219,7 @@
                             {
                                 "name": "keyVaultSSLCertPasswordSecretName",
                                 "type": "Microsoft.Common.TextBox",
-                                "label": "The name of the secret in the specified Key Vault whose value is the password for the TLS/SSL certificate",
+                                "label": "The name of the secret in the specified Key Vault whose value is the password for the frontend TLS/SSL certificate",
                                 "defaultValue": "",
                                 "toolTip": "Use only letters and numbers",
                                 "constraints": {
@@ -1212,6 +1228,19 @@
                                     "validationMessage": "The value must be 1-30 characters long and must only contain letters and numbers."
                                 },
                                 "visible": "[equals(steps('section_appGateway').appgwIngress.certificateOption, 'haveKeyVault')]"
+                            },
+                            {
+                                "name": "keyVaultBackendSSLCertDataSecretName",
+                                "type": "Microsoft.Common.TextBox",
+                                "label": "The name of the secret in the specified Key Vault whose value is the trusted root certificate data",
+                                "defaultValue": "",
+                                "toolTip": "Use only letters and numbers",
+                                "constraints": {
+                                    "required": true,
+                                    "regex": "^[a-z0-9A-Z]{1,30}$",
+                                    "validationMessage": "The value must be 1-30 characters long and must only contain letters and numbers."
+                                },
+                                "visible": "[and(steps('section_sslConfiguration').enableCustomSSL, equals(steps('section_appGateway').appgwIngress.certificateOption, 'haveKeyVault'))]"
                             },
                             {
                                 "name": "servicePrincipal",
@@ -1533,6 +1562,7 @@
             "aksClusterName": "[last(split(steps('section_aks').clusterInfo.aksClusterSelector.id, '/'))]",
             "aksClusterRGName": "[last(take(split(steps('section_aks').clusterInfo.aksClusterSelector.id, '/'), 5))]",
             "appGatewayCertificateOption": "[steps('section_appGateway').appgwIngress.certificateOption]",
+            "appGatewaySSLBackendRootCertData": "[steps('section_appGateway').appgwIngress.keyVaultBackendSSLCertData]",
             "appGatewaySSLCertData": "[steps('section_appGateway').appgwIngress.keyVaultSSLCertData]",
             "appGatewaySSLCertPassword": "[steps('section_appGateway').appgwIngress.appGatewaySSLCertPassword]",
             "appgwForAdminServer": "[steps('section_appGateway').appgwIngress.appgwForAdminServer]",
@@ -1563,6 +1593,7 @@
             "location": "[location()]",
             "keyVaultName": "[steps('section_appGateway').appgwIngress.keyVaultName]",
             "keyVaultResourceGroup": "[steps('section_appGateway').appgwIngress.keyVaultResourceGroup]",
+            "keyVaultSSLBackendRootCertDataSecretName": "[steps('section_appGateway').appgwIngress.keyVaultBackendSSLCertDataSecretName]",
             "keyVaultSSLCertDataSecretName": "[steps('section_appGateway').appgwIngress.keyVaultSSLCertDataSecretName]",
             "keyVaultSSLCertPasswordSecretName": "[steps('section_appGateway').appgwIngress.keyVaultSSLCertPasswordSecretName]",
             "managedServerPrefix": "[basics('basicsOptional').managedServerPrefix]",

--- a/weblogic-azure-aks/src/main/arm/scripts/setupWLSDomain.sh
+++ b/weblogic-azure-aks/src/main/arm/scripts/setupWLSDomain.sh
@@ -427,20 +427,12 @@ function output_ssl_keystore() {
     else
         rm -f ${mntPath}/$wlsIdentityKeyStoreFileName
         rm -f ${mntPath}/$wlsTrustKeyStoreFileName
-        rm -f ${mntPath}/${wlsIdentityRootCertFileName}
         rm -f ${mntPath}/${wlsTrustKeyStoreJKSFileName}
     fi
 
     #decode cert data once again as it would got base64 encoded
     echo "$wlsIdentityData" | base64 -d >${mntPath}/$wlsIdentityKeyStoreFileName
     echo "$wlsTrustData" | base64 -d >${mntPath}/$wlsTrustKeyStoreFileName
-    # export root cert. Used as gateway backend certificate
-    ${JAVA_HOME}/bin/keytool -export \
-        -alias ${wlsIdentityAlias} \
-        -noprompt \
-        -file ${mntPath}/${wlsIdentityRootCertFileName} \
-        -keystore ${mntPath}/$wlsIdentityKeyStoreFileName \
-        -storepass ${wlsIdentityPsw}
 
     # export jks file
     # -Dweblogic.security.SSL.trustedCAKeyStorePassPhrase for PKCS12 is not working correctly
@@ -744,7 +736,6 @@ export wlsOptVersion="3.2.5"
 export wlsIdentityKeyStoreFileName="security/identity.keystore"
 export wlsTrustKeyStoreFileName="security/trust.keystore"
 export wlsTrustKeyStoreJKSFileName="security/trust.jks"
-export wlsIdentityRootCertFileName="security/root.cert"
 
 read_sensitive_parameters_from_stdin
 

--- a/weblogic-azure-aks/src/main/arm/scripts/uploadAppGatewayTrutedRootCert.sh
+++ b/weblogic-azure-aks/src/main/arm/scripts/uploadAppGatewayTrutedRootCert.sh
@@ -1,0 +1,25 @@
+# Copyright (c) 2021, Oracle Corporation and/or its affiliates.
+# Licensed under the Universal Permissive License v 1.0 as shown at https://oss.oracle.com/licenses/upl.
+# This script runs on Azure Container Instance with Alpine Linux that Azure Deployment script creates.
+
+# upload trusted root certificate to Azure Application Gateway
+# $1: resource group name
+# $2: Application Gateway name
+# $3: one line based64 string of the certificate data
+
+# The value is used in setupNetworking.sh, please do not change it.
+export appgwBackendSecretName='backend-tls'
+
+echo "output certificate data to backend-cert.cer"
+echo "$3" | base64 -d >backend-cert.cer
+
+az network application-gateway root-cert create \
+      --gateway-name $2  \
+      --resource-group $1 \
+      --name ${appgwBackendSecretName} \
+      --cert-file backend-cert.cer
+
+if [ $? -ne 0 ]; then
+    echo "Failed to upload trusted root certificate to Application Gateway ${2}"
+    exit 1
+fi

--- a/weblogic-azure-aks/src/main/bicep/modules/_azure-resoruces/_keyvault/_keyvaultForGatewayBackendCert.bicep
+++ b/weblogic-azure-aks/src/main/bicep/modules/_azure-resoruces/_keyvault/_keyvaultForGatewayBackendCert.bicep
@@ -1,0 +1,49 @@
+// Copyright (c) 2021, Oracle Corporation and/or its affiliates.
+// Licensed under the Universal Permissive License v 1.0 as shown at https://oss.oracle.com/licenses/upl.
+
+@description('Secret name of certificate data.')
+param certificateDataName string
+
+@description('Certificate data to store in the secret')
+param certificateDataValue string
+
+@description('Property to specify whether Azure Resource Manager is permitted to retrieve secrets from the key vault.')
+param enabledForTemplateDeployment bool = true
+
+@description('Name of the vault')
+param keyVaultName string
+
+@description('Price tier for Key Vault.')
+param sku string
+
+param utcValue string = utcNow()
+
+resource keyvault 'Microsoft.KeyVault/vaults@2019-09-01' = {
+  name: keyVaultName
+  location: resourceGroup().location
+  properties: {
+    enabledForTemplateDeployment: enabledForTemplateDeployment
+    sku: {
+      name: sku
+      family: 'A'
+    }
+    accessPolicies: []
+    tenantId: subscription().tenantId
+  }
+  tags:{
+    'managed-by-azure-weblogic': utcValue
+  }
+}
+
+resource secretForCertificate 'Microsoft.KeyVault/vaults/secrets@2019-09-01' = {
+  name: '${keyVaultName}/${certificateDataName}'
+  properties: {
+    value: certificateDataValue
+  }
+  dependsOn: [
+    keyvault
+  ]
+}
+
+output keyVaultName string = keyVaultName
+output sslBackendCertDataSecretName string = certificateDataName

--- a/weblogic-azure-aks/src/main/bicep/modules/_deployment-scripts/_ds-appgw-upload-trusted-root-certificate.bicep
+++ b/weblogic-azure-aks/src/main/bicep/modules/_deployment-scripts/_ds-appgw-upload-trusted-root-certificate.bicep
@@ -1,0 +1,27 @@
+// Copyright (c) 2021, Oracle Corporation and/or its affiliates.
+// Licensed under the Universal Permissive License v 1.0 as shown at https://oss.oracle.com/licenses/upl.
+
+param appgwName string
+@secure()
+param sslBackendRootCertData string = newGuid()
+param identity object
+param utcValue string = utcNow()
+
+var const_arguments = '${resourceGroup().name} ${appgwName} ${sslBackendRootCertData}'
+var const_azcliVersion='2.15.0'
+var const_deploymentName='ds-upload-trusted-root-certificatre-to-gateway'
+
+resource deploymentScript 'Microsoft.Resources/deploymentScripts@2020-10-01' = {
+  name: const_deploymentName
+  location: resourceGroup().location
+  kind: 'AzureCLI'
+  identity: identity
+  properties: {
+    azCliVersion: const_azcliVersion
+    arguments: const_arguments
+    scriptContent: loadTextContent('../../../arm/scripts/uploadAppGatewayTrutedRootCert.sh')
+    cleanupPreference: 'OnSuccess'
+    retentionInterval: 'P1D'
+    forceUpdateTag: utcValue
+  }
+}


### PR DESCRIPTION
### Requirement
For signed certificate, we have to upload the CA certificate to Azure Application Gateway, see [Certificates required to allow backend servers](https://docs.microsoft.com/en-us/azure/application-gateway/certificates-for-backend-authentication).

### Changes

- **[UI]** Set gateway default certificate option with "Upload Certificate"
- **[UI]** Create control to upload/refer to backend server CA certificate.
- Upload the CA certificate to Application Gateway.

### Test

- Test with self-signed certificate
- Test with `admin.wlseng-azuretest.org` CA certificate which was obtained from @jacobt123 
