### PR TITLE
Fix bugs found in the E2E test.

### DIFF
--- a/weblogic-azure-aks/pom.xml
+++ b/weblogic-azure-aks/pom.xml
@@ -11,7 +11,7 @@
 
   <groupId>com.oracle.weblogic.azure</groupId>
   <artifactId>wls-on-aks-azure-marketplace</artifactId>
-  <version>1.0.17</version>
+  <version>1.0.18</version>
 
   <parent>
     <groupId>com.microsoft.azure.iaas</groupId>

--- a/weblogic-azure-aks/src/main/arm/createUiDefinition.json
+++ b/weblogic-azure-aks/src/main/arm/createUiDefinition.json
@@ -996,7 +996,7 @@
                                     "rows": {
                                         "count": {
                                             "min": 0,
-                                            "max": 10
+                                            "max": 4
                                         }
                                     },
                                     "columns": [
@@ -1011,8 +1011,12 @@
                                                     "required": true,
                                                     "validations": [
                                                         {
-                                                            "regex": "^[a-z0-9A-Z-]{1,30}$",
-                                                            "message": "Only alphanumeric characters are allowed, and the value must be 1-30 characters long."
+                                                            "isValid": "[lessOrEquals(length(filter(steps('section_appGateway').lbSVCInfo.lbSVC, (item) => equals(item.colName, last(take(steps('section_appGateway').lbSVCInfo.lbSVC, $rowIndex)).colName))),1)]",
+                                                            "message": "You can not input the same service prefix repeadly, please change any of the value."
+                                                        },
+                                                        {
+                                                            "regex": "^(?=.{3,20}$)[a-zA-Z](([a-z0-9A-Z]*|(?:\\-[^\\-][a-z0-9A-Z]*))*)",
+                                                            "message": "The prefix must be between 3 and 20 characters long and contain letters, numbers and hyphens(-). The name must begin with a letter, end with a letter or digit, and not contain consecutive hyphens."
                                                         }
                                                     ]
                                                 }
@@ -1060,7 +1064,11 @@
                                                     "required": true,
                                                     "validations": [
                                                         {
-                                                            "regex": "^[0-9]{1,5}$",
+                                                            "isValid": "[lessOrEquals(length(filter(steps('section_appGateway').lbSVCInfo.lbSVC, (item) => equals(item.colTarget, last(take(steps('section_appGateway').lbSVCInfo.lbSVC, $rowIndex)).colTarget))),1)]",
+                                                            "message": "You can not select the same target repeadly."
+                                                        },
+                                                        {
+                                                            "regex": "^()([1-9]|[1-5]?[0-9]{2,4}|6[1-4][0-9]{3}|65[1-4][0-9]{2}|655[1-2][0-9]|6553[1-5])$",
                                                             "message": "Only numbers are allowed, and the value must be 1-65535."
                                                         }
                                                     ]

--- a/weblogic-azure-aks/src/main/arm/createUiDefinition.json
+++ b/weblogic-azure-aks/src/main/arm/createUiDefinition.json
@@ -168,8 +168,8 @@
                         "defaultValue": "managed-server",
                         "constraints": {
                             "required": true,
-                            "regex": "^[a-z0-9A-Z\\-]{3,20}$",
-                            "validationMessage": "The prefix must be between 3 and 20 characters long and contain letters, numbers and -."
+                            "regex": "^(?=.{3,20}$)[a-zA-Z](([a-z0-9A-Z]*|(?:\\-[^\\-][a-z0-9A-Z]*))*)",
+                            "validationMessage": "The prefix must be between 3 and 20 characters long and contain letters, numbers and hyphens(-). The name must begin with a letter, end with a letter or digit, and not contain consecutive hyphens."
                         },
                         "visible": "[bool(basics('basicsOptional').basicsOptionalAcceptDefaults)]"
                     },

--- a/weblogic-azure-aks/src/main/arm/createUiDefinition.json
+++ b/weblogic-azure-aks/src/main/arm/createUiDefinition.json
@@ -1412,7 +1412,7 @@
                         "type": "Microsoft.Common.TextBox",
                         "label": "DNS Zone Name",
                         "defaultValue": "",
-                        "toolTip": "Use only letters and numbers and periods to separate Domains",
+                        "toolTip": "Each label must only contain letters, numbers, underscores, and dashes. Use periods to separate Domains",
                         "constraints": {
                             "required": true,
                             "regex": "^([0-9a-zA-Z_-]{1,63}\\.){1,33}[0-9a-zA-Z_-]{1,63}$",

--- a/weblogic-azure-aks/src/main/arm/createUiDefinition.json
+++ b/weblogic-azure-aks/src/main/arm/createUiDefinition.json
@@ -1595,8 +1595,8 @@
                                 "defaultValue": "",
                                 "constraints": {
                                     "required": "[bool(steps('section_database').enableDB)]",
-                                    "regex": "^[a-z0-9A-Z/]{1,30}$",
-                                    "validationMessage": "The value must be 1-30 characters long and must only contain letters, numbers, and slashes (/)."
+                                    "regex": "^[a-zA-Z0-9./_-]{1,30}$",
+                                    "validationMessage": "The value must be 1-30 characters long and must only contain letters, numbers, hyphens (-), underscores (_), periods (.) and slashes (/)."
                                 },
                                 "visible": true
                             },

--- a/weblogic-azure-aks/src/main/arm/createUiDefinition.json
+++ b/weblogic-azure-aks/src/main/arm/createUiDefinition.json
@@ -351,7 +351,7 @@
                                 "label": "Node count",
                                 "defaultValue": 2,
                                 "showStepMarkers": false,
-                                "toolTip": "The number of nodes that should be created along with the cluster. You will be able to resize the cluster later",
+                                "toolTip": "The number of nodes that should be created along with the cluster. You will be able to resize the cluster later.",
                                 "constraints": {
                                     "required": true
                                 },
@@ -375,7 +375,7 @@
                                     "hideDiskTypeFilter": false
                                 },
                                 "osPlatform": "Linux",
-                                "count": 2,
+                                "count": "[steps('section_aks').clusterInfo.aksNodeCount]",
                                 "visible": "[bool(steps('section_aks').clusterInfo.createAKSCluster)]"
                             },
                             {

--- a/weblogic-azure-aks/src/main/arm/createUiDefinition.json
+++ b/weblogic-azure-aks/src/main/arm/createUiDefinition.json
@@ -1621,7 +1621,7 @@
                                 "defaultValue": "",
                                 "constraints": {
                                     "required": "[bool(steps('section_database').enableDB)]",
-                                    "regex": "^(?!\\-)([a-z0-9A-Z@\\-]{1,128})([^\\-])$",
+                                    "regex": "^(?=.{1,128}$)[a-zA-Z](?!.*--)(?!.*@@)(?!.*-@)(?!.*@-)[a-zA-Z0-9-@]*[a-zA-Z0-9]$",
                                     "validationMessage": "The value must be 1-128 characters long and must only contain letters, numbers, hyphen(-) and the at sign, no hyphen allowed at the beginning and the end of database username."
                                 },
                                 "visible": true
@@ -1637,7 +1637,7 @@
                                 "constraints": {
                                     "required": "[bool(steps('section_database').enableDB)]",
                                     "regex": "^((?=.*[0-9])(?=.*[a-zA-Z!@#$%^&*])).{5,128}$",
-                                    "validationMessage": "The password must be between five and 128 characters long and have at least one number."
+                                    "validationMessage": "The password must be between 5 and 128 characters long and have at least one number."
                                 },
                                 "options": {
                                     "hideConfirmation": false

--- a/weblogic-azure-aks/src/main/arm/createUiDefinition.json
+++ b/weblogic-azure-aks/src/main/arm/createUiDefinition.json
@@ -168,7 +168,7 @@
                         "defaultValue": "managed-server",
                         "constraints": {
                             "required": true,
-                            "regex": "^(?=.{3,20}$)[a-zA-Z](([a-z0-9A-Z]*|(?:\\-[^\\-][a-z0-9A-Z]*))*)",
+                            "regex": "^(?=.{3,20}$)[a-zA-Z](?!.*--)[a-zA-Z0-9-]*[a-zA-Z0-9]$",
                             "validationMessage": "The prefix must be between 3 and 20 characters long and contain letters, numbers and hyphens(-). The name must begin with a letter, end with a letter or digit, and not contain consecutive hyphens."
                         },
                         "visible": "[bool(basics('basicsOptional').basicsOptionalAcceptDefaults)]"
@@ -194,8 +194,8 @@
                         "defaultValue": "sample-domain1",
                         "constraints": {
                             "required": true,
-                            "regex": "^[a-z0-9A-Z\\-]{3,20}$",
-                            "validationMessage": "The Domain UID must be between 3 and 20 characters long and contain letters, numbers and -."
+                            "regex": "^(?=.{3,20}$)[a-zA-Z](?!.*--)[a-zA-Z0-9-]*[a-zA-Z0-9]$",
+                            "validationMessage": "The prefix must be between 3 and 20 characters long and contain letters, numbers and hyphens(-). The name must begin with a letter, end with a letter or digit, and not contain consecutive hyphens."
                         },
                         "visible": "[bool(basics('basicsOptional').basicsOptionalAcceptDefaults)]"
                     },
@@ -804,7 +804,7 @@
                                 "toolTip": "Use only letters and numbers",
                                 "constraints": {
                                     "required": true,
-                                    "regex": "^(?=.{3,24}$)[a-zA-Z](([a-z0-9A-Z]*|(?:\\-[^\\-][a-z0-9A-Z]*))*)$",
+                                    "regex": "^(?=.{3,24}$)[a-zA-Z](?!.*--)[a-zA-Z0-9-]*[a-zA-Z0-9]$",
                                     "validationMessage": "[if(or(greater(length(steps('section_sslConfiguration').keyVaultStoredCustomSSLSettings.keyVaultName), 24), less(length(steps('section_sslConfiguration').keyVaultStoredCustomSSLSettings.keyVaultName), 3)),'Vault name must be between 3-24 alphanumeric characters. The name must begin with a letter, end with a letter or digit, and not contain consecutive hyphens.','Vault name must only contain alphanumeric characters and dashes and cannot start with a number')]"
                                 }
                             },
@@ -1015,7 +1015,7 @@
                                                             "message": "You can not input the same service prefix repeadly, please change any of the value."
                                                         },
                                                         {
-                                                            "regex": "^(?=.{3,20}$)[a-zA-Z](([a-z0-9A-Z]*|(?:\\-[^\\-][a-z0-9A-Z]*))*)",
+                                                            "regex": "^(?=.{3,20}$)[a-zA-Z](?!.*--)[a-zA-Z0-9-]*[a-zA-Z0-9]$",
                                                             "message": "The prefix must be between 3 and 20 characters long and contain letters, numbers and hyphens(-). The name must begin with a letter, end with a letter or digit, and not contain consecutive hyphens."
                                                         }
                                                     ]
@@ -1238,7 +1238,7 @@
                                 "toolTip": "Use only letters and numbers",
                                 "constraints": {
                                     "required": true,
-                                    "regex": "^(?=.{3,24}$)[a-zA-Z](([a-z0-9A-Z]*|(?:\\-[^\\-][a-z0-9A-Z]*))*)$",
+                                    "regex": "^(?=.{3,24}$)[a-zA-Z](?!.*--)[a-zA-Z0-9-]*[a-zA-Z0-9]$",
                                     "validationMessage": "[if(or(greater(length(steps('section_appGateway').appgwIngress.keyVaultName), 24), less(length(steps('section_appGateway').appgwIngress.keyVaultName), 3)),'Vault name must be between 3-24 alphanumeric characters. The name must begin with a letter, end with a letter or digit, and not contain consecutive hyphens.','Vault name must only contain alphanumeric characters and dashes and cannot start with a number')]"
                                 },
                                 "visible": "[equals(steps('section_appGateway').appgwIngress.certificateOption, 'haveKeyVault')]"

--- a/weblogic-azure-aks/src/main/arm/createUiDefinition.json
+++ b/weblogic-azure-aks/src/main/arm/createUiDefinition.json
@@ -453,7 +453,7 @@
                                 "type": "Microsoft.Common.TextBlock",
                                 "visible": true,
                                 "options": {
-                                    "text": "This value is appended to 'container-registry.oracle.com/middleware/weblogic:' and used in the Dockerfile FROM statement. \nOracle Standard Terms and Restrictions terms must be agreed. \nClick the following link to make sure you have agree the terms and check the valid tags.",
+                                    "text": "This value is appended to 'container-registry.oracle.com/middleware/weblogic:' and used in the Dockerfile from statement. \nOracle Standard Terms and Restrictions terms must be agreed. \nClick the following link to make sure you have agree the terms and check the valid tags.",
                                     "link": {
                                         "label": "Must be a valid tag value from Oracle Container Registry",
                                         "uri": "https://aka.ms/wls-aks-fromImage-tag?${project.version}-${maven.build.timestamp}"
@@ -508,10 +508,11 @@
                             {
                                 "name": "appPackageUrl",
                                 "type": "Microsoft.Common.FileUpload",
-                                "label": "Application package (.war,.ear)",
-                                "toolTip": "The application war package to deploy.",
+                                "label": "Application package (.war,.ear,.jar)",
+                                "toolTip": "The application package to deploy.",
                                 "constraints": {
-                                    "required": true
+                                    "required": true,
+                                    "accept": ".war,.ear,.jar"
                                 },
                                 "options": {
                                     "multiple": true,

--- a/weblogic-azure-aks/src/main/arm/createUiDefinition.json
+++ b/weblogic-azure-aks/src/main/arm/createUiDefinition.json
@@ -1193,7 +1193,7 @@
                                 "toolTip": "Frontend TLS/SSL certificate password",
                                 "constraints": {
                                     "required": "[equals(steps('section_appGateway').appgwIngress.certificateOption, 'haveCert')]",
-                                    "regex": "^((?=.*[0-9])(?=.*[a-z])|(?=.*[0-9])(?=.*[a-z])(?=.*[A-Z])|(?=.*[0-9])(?=.*[a-z])(?=.*[!@#$%^&*])|(?=.*[0-9])(?=.*[A-Z])(?=.*[!@#$%^&*])|(?=.*[a-z])(?=.*[A-Z])(?=.*[!@#$%^&*])).{6,128}$",
+                                    "regex": "^((?=.*[0-9])(?=.*[a-z])(?=.*[A-Z])(?=.*[!@#$%^&*])).{6,128}$",
                                     "validationMessage": "The password must contain at least 6 characters, with at least 1 uppercase letter, 1 lowercase letter and 1 number."
                                 },
                                 "options": {

--- a/weblogic-azure-aks/src/main/arm/createUiDefinition.json
+++ b/weblogic-azure-aks/src/main/arm/createUiDefinition.json
@@ -99,7 +99,7 @@
                         "toolTip": "Password for Oracle Single Sign-On authentication to login the Oracle Container Registry.",
                         "constraints": {
                             "required": true,
-                            "regex": "^(?=.*[A-Z])(?=.*[a-z])(?=.*\\d)[A-Za-z\\d\\$\\&\\+\\,:;\\=\\?@#|'.\\^\\*!\\-_~/'\\[\\]\\{\\}\"]{8,}$",
+                            "regex": "^(?=.*[A-Z])(?=.*[a-z])(?=.*\\d)[A-Za-z\\d\\$\\&\\+\\,:\\=\\?@#|'.\\^\\*!\\-_~/'\\[\\]\\{\\}\"]{8,}$",
                             "validationMessage": "The password must contain at least 8 characters, with at least 1 uppercase letter, 1 lowercase letter and 1 number, and special characters, but should not contain > < ( ) % ; \\."
                         },
                         "options": {

--- a/weblogic-azure-aks/src/main/arm/scripts/createAppGatewayIngress.sh
+++ b/weblogic-azure-aks/src/main/arm/scripts/createAppGatewayIngress.sh
@@ -492,7 +492,7 @@ function appgw_ingress_svc_for_cluster() {
     generate_appgw_cluster_config_file
     kubectl apply -f ${clusterAppgwIngressYamlPath}
     utility_validate_status "Create appgw ingress svc."
-    utility_waitfor_lb_svc_completed \
+    utility_waitfor_ingress_completed \
         ${clusterIngressName} \
         ${wlsDomainNS} \
         ${checkSVCStateMaxAttempt} \
@@ -502,7 +502,7 @@ function appgw_ingress_svc_for_cluster() {
     if [[ "${enableCustomSSL,,}" != "true" ]]; then
         kubectl apply -f ${clusterAppgwIngressHttpsYamlPath}
         utility_validate_status "Create appgw ingress https svc."
-        utility_waitfor_lb_svc_completed \
+        utility_waitfor_ingress_completed \
             ${clusterIngressHttpsName} \
             ${wlsDomainNS} \
             ${checkSVCStateMaxAttempt} \

--- a/weblogic-azure-aks/src/main/arm/scripts/createLbSvc.sh
+++ b/weblogic-azure-aks/src/main/arm/scripts/createLbSvc.sh
@@ -234,7 +234,7 @@ function create_lb_svc_for_cluster_default_channel() {
 
   if [ "${enableCustomDNSAlias,,}" == "true" ]; then
     create_dns_A_record "${clusterEndpoint%%:*}" ${dnsClusterLabel} ${dnsRGName} ${dnsZoneName}
-    clusterEndpoint="${dnsClusterLabel}.${dnsZoneName}:${clusterEndpoint#*:}/"
+    clusterEndpoint="${dnsClusterLabel}.${dnsZoneName}:${clusterEndpoint#*:}"
   fi
 }
 

--- a/weblogic-azure-aks/src/main/arm/scripts/createLbSvc.sh
+++ b/weblogic-azure-aks/src/main/arm/scripts/createLbSvc.sh
@@ -180,12 +180,14 @@ function create_lb_svc_for_admin_server_default_channel() {
 
   adminServerEndpoint=$(kubectl get svc ${adminServerLBSVCName} -n ${wlsDomainNS} \
     -o=jsonpath='{.status.loadBalancer.ingress[0].ip}:{.spec.ports[0].port}')
-  adminConsoleEndpoint="${adminServerEndpoint}/console"
 
   if [ "${enableCustomDNSAlias,,}" == "true" ]; then
     create_dns_A_record "${adminServerEndpoint%%:*}" ${dnsAdminLabel} ${dnsRGName} ${dnsZoneName}
-    adminConsoleEndpoint="${dnsAdminLabel}.${dnsZoneName}:${adminServerEndpoint#*:}/console"
+    adminServerEndpoint="${dnsAdminLabel}.${dnsZoneName}:${adminServerEndpoint#*:}"
   fi
+
+  adminConsoleEndpoint="${adminServerEndpoint}/console"
+  adminRemoteEndpoint=${adminServerEndpoint}
 }
 
 function create_lb_svc_for_admin_t3_channel() {
@@ -360,19 +362,48 @@ EOF
   fi
 }
 
+function validate_admin_console_url() {
+  local podName=$(kubectl -n ${wlsDomainNS} get pod -l weblogic.serverName=${constAdminServerName} -o json |
+    jq '.items[0] | .metadata.name' |
+    tr -d "\"")
+
+  if [[ "${podName}" == "null" ]]; then
+    echo "Ensure your domain has at least one admin server."
+    exit 1
+  fi
+
+  adminTargetPort=$(kubectl get svc ${svcAdminServer} -n ${wlsDomainNS} -o json |
+    jq '.spec.ports[] | select(.name=="default") | .port')
+  local adminConsoleUrl="http://${svcAdminServer}.${wlsDomainNS}:${adminTargetPort}/console/"
+
+  kubectl exec -it ${podName} -n ${wlsDomainNS} -c ${wlsContainerName} \
+    -- bash -c 'curl --write-out "%{http_code}\n" --silent --output /dev/null "'${adminConsoleUrl}'" | grep "302"'
+
+  if [ $? == 1 ]; then
+    echo "admin console is not accessible."
+    # reset admin console endpoint
+    adminConsoleEndpoint="null"
+  fi
+}
+
 #Output value to deployment scripts
 function output_result() {
   echo ${adminConsoleEndpoint}
   echo ${clusterEndpoint}
   echo ${adminServerT3Endpoint}
   echo ${clusterT3Endpoint}
+  echo ${adminRemoteEndpoint}
+
+  # check if the admin console is accessible, do not output it
+  validate_admin_console_url
 
   result=$(jq -n -c \
     --arg adminEndpoint $adminConsoleEndpoint \
     --arg clusterEndpoint $clusterEndpoint \
     --arg adminT3Endpoint $adminServerT3Endpoint \
     --arg clusterT3Endpoint $clusterT3Endpoint \
-    '{adminConsoleEndpoint: $adminEndpoint, clusterEndpoint: $clusterEndpoint, adminServerT3Endpoint: $adminT3Endpoint, clusterT3Endpoint: $clusterT3Endpoint}')
+    --arg adminRemoteEndpoint ${adminRemoteEndpoint} \
+    '{adminConsoleEndpoint: $adminEndpoint, clusterEndpoint: $clusterEndpoint, adminServerT3Endpoint: $adminT3Endpoint, clusterT3Endpoint: $clusterT3Endpoint, adminRemoteEndpoint: $adminRemoteEndpoint}')
   echo "result is: $result"
   echo $result >$AZ_SCRIPTS_OUTPUT_PATH
 }
@@ -461,6 +492,7 @@ wlsDomainUID=${11}
 adminConsoleEndpoint="null"
 adminServerName=${constAdminServerName} # define in common.sh
 adminServerT3Endpoint="null"
+adminRemoteEndpoint="null"
 clusterEndpoint="null"
 clusterName=${constClusterName}
 clusterT3Endpoint="null"

--- a/weblogic-azure-aks/src/main/arm/scripts/genImageModel.sh
+++ b/weblogic-azure-aks/src/main/arm/scripts/genImageModel.sh
@@ -175,6 +175,14 @@ EOF
         fileName="${urlWithoutQueryString##*/}"
         echo $fileName
         fileExtension="${fileName##*.}"
+        echo ${fileExtension}
+        # support .ear, .war, .jar files.
+        if [[ "${fileExtension,,}" != "ear" ]] &&
+          [[ "${fileExtension,,}" != "war" ]] &&
+          [[ "${fileExtension,,}" != "jar" ]]; then
+          continue
+        fi
+
         curl -m ${curlMaxTime} -fL "$item" -o ${scriptDir}/model-images/wlsdeploy/applications/${fileName}
         if [ $? -ne 0 ];then
           echo "Failed to download $item"

--- a/weblogic-azure-aks/src/main/arm/scripts/queryStorageAccount.sh
+++ b/weblogic-azure-aks/src/main/arm/scripts/queryStorageAccount.sh
@@ -1,35 +1,30 @@
 export aksClusterRGName=$1
 export aksClusterName=$2
-export wlsDomainUID=$3
 
-export wlsDomainNS="${wlsDomainUID}-ns"
 export currentStorageAccount="null"
 
 # Connect to AKS cluster
 function connect_aks_cluster() {
-    az aks get-credentials \
-        --resource-group ${aksClusterRGName} \
-        --name ${aksClusterName} \
-        --overwrite-existing
+  az aks get-credentials \
+    --resource-group ${aksClusterRGName} \
+    --name ${aksClusterName} \
+    --overwrite-existing
 }
 
 function query_storage_account() {
-    echo "install kubectl"
-    az aks install-cli
+  echo "install kubectl"
+  az aks install-cli
 
-    echo "get pv, pvc"
-    pvcName=${wlsDomainUID}-pvc-azurefile
-    pvName=${wlsDomainUID}-pv-azurefile
-    
-    ret=$(kubectl -n ${wlsDomainNS} get pvc ${pvcName} | grep "Bound")
+  echo "get pv name"
+  pvName=$(kubectl get pv -o json |
+    jq '.items[] | select(.status.phase=="Bound") | [.metadata.name] | .[0]' |
+    tr -d "\"")
 
-    if [ -n "$ret" ]; then
-        echo "pvc is bound to namespace ${wlsDomainNS}."
-        # this is a workaround for update domain using marketplace offer.
-        # the offer will create a new storage account in a new resource group.
-        # remove the new storage account.
-        currentStorageAccount=$(kubectl get pv ${pvName} -o json | jq '. | .metadata.labels.storageAccount' | tr -d "\"")
-    fi
+  if [[ "${pvName}" != "null" ]] && [[ "${pvName}" != "" ]]; then
+    # this is a workaround for update domain using marketplace offer.
+    # the offer will create a new storage account in a new resource group if there is no storage attached.
+    currentStorageAccount=$(kubectl get pv ${pvName} -o json | jq '. | .metadata.labels.storageAccount' | tr -d "\"")
+  fi
 }
 
 function output_result() {

--- a/weblogic-azure-aks/src/main/arm/scripts/updateApplications.sh
+++ b/weblogic-azure-aks/src/main/arm/scripts/updateApplications.sh
@@ -129,7 +129,7 @@ function get_app_sas_url() {
     while [ $index -lt $appNumber ]; do
         appName=${args[${index}]}
         echo "app package file name: ${appName}"
-        if [[ "$appName" == *".war" || "$appName" == *".ear" ]]; then
+        if [[ "$appName" == *".war" || "$appName" == *".ear" || "$appName" == *".jar" ]]; then
             appSaSUrl=$(az storage blob url --container-name ${appContainerName} \
                 --name ${appName} \
                 --account-name ${appStorageAccountName} \

--- a/weblogic-azure-aks/src/main/bicep/mainTemplate.bicep
+++ b/weblogic-azure-aks/src/main/bicep/mainTemplate.bicep
@@ -260,12 +260,13 @@ var const_wlsJavaOptions = wlsJavaOption == '' ? 'null' : wlsJavaOption
 var const_wlsSSLCertOptionKeyVault = 'keyVaultStoredConfig'
 var name_defaultPidDeployment = 'pid'
 var name_dnsNameforApplicationGateway = '${concat(dnsNameforApplicationGateway, take(utcValue, 6))}'
-var name_domainLabelforApplicationGateway = '${take(concat(name_dnsNameforApplicationGateway, '-', toLower(resourceGroup().name), '-', toLower(wlsDomainName)), 63)}'
+var name_domainLabelforApplicationGateway = '${take(concat(name_dnsNameforApplicationGateway, '-', toLower(name_rgNameWithoutSpecialCharacter), '-', toLower(wlsDomainName)), 63)}'
 var name_identityKeyStoreDataSecret = (sslConfigurationAccessOption == const_wlsSSLCertOptionKeyVault) ? sslKeyVaultCustomIdentityKeyStoreDataSecretName : 'myIdentityKeyStoreData'
 var name_identityKeyStorePswSecret = (sslConfigurationAccessOption == const_wlsSSLCertOptionKeyVault) ? sslKeyVaultCustomIdentityKeyStorePassPhraseSecretName : 'myIdentityKeyStorePsw'
 var name_keyVaultName = empty(const_keyvaultNameFromTag) ? '${take(concat('wls-kv', uniqueString(utcValue)), 24)}' : resourceGroup().tags.wlsKeyVault
 var name_privateKeyAliasSecret = (sslConfigurationAccessOption == const_wlsSSLCertOptionKeyVault) ? sslKeyVaultPrivateKeyAliasSecretName : 'privateKeyAlias'
 var name_privateKeyPswSecret = (sslConfigurationAccessOption == const_wlsSSLCertOptionKeyVault) ? sslKeyVaultPrivateKeyPassPhraseSecretName : 'privateKeyPsw'
+var name_rgNameWithoutSpecialCharacter= replace(replace(replace(replace(resourceGroup().name, '.', ''), '(', ''), ')', ''), '_', '') // remove . () _ from resource group name
 var name_rgKeyvaultForWLSSSL = (sslConfigurationAccessOption == const_wlsSSLCertOptionKeyVault) ? sslKeyVaultResourceGroup : resourceGroup().name
 var name_storageAccountName = const_hasStorageAccount ? reference('query-existing-storage-account').outputs.storageAccount.value : 'wls${uniqueString(utcValue)}'
 var name_tagNameForKeyVault = 'wlsKeyVault'

--- a/weblogic-azure-aks/src/main/bicep/mainTemplate.bicep
+++ b/weblogic-azure-aks/src/main/bicep/mainTemplate.bicep
@@ -323,7 +323,6 @@ module queryStorageAccount 'modules/_deployment-scripts/_ds-query-storage-accoun
     aksClusterName: aksClusterName
     aksClusterRGName: aksClusterRGName
     identity: identity
-    wlsDomainUID: wlsDomainUID
   }
 }
 

--- a/weblogic-azure-aks/src/main/bicep/modules/_azure-resoruces/_appgateway.bicep
+++ b/weblogic-azure-aks/src/main/bicep/modules/_azure-resoruces/_appgateway.bicep
@@ -2,7 +2,7 @@
 // Licensed under the Universal Permissive License v 1.0 as shown at https://oss.oracle.com/licenses/upl.
 
 @description('DNS for ApplicationGateway')
-param dnsNameforApplicationGateway string = take('wlsgw${uniqueString(utcValue)}-${toLower(resourceGroup().name)}', 63)
+param dnsNameforApplicationGateway string = take('wlsgw${uniqueString(utcValue)}', 63)
 @description('Public IP Name for the Application Gateway')
 param gatewayPublicIPAddressName string = 'gwip'
 param utcValue string = utcNow()

--- a/weblogic-azure-aks/src/main/bicep/modules/_deployment-scripts/_ds-create-networking.bicep
+++ b/weblogic-azure-aks/src/main/bicep/modules/_deployment-scripts/_ds-create-networking.bicep
@@ -54,6 +54,7 @@ var const_scriptLocation = uri(_artifactsLocation, 'scripts/')
 var const_setupNetworkingScript= 'setupNetworking.sh'
 var const_primaryScript = 'invokeSetupNetworking.sh'
 var const_utilityScript= 'utility.sh'
+var name_deploymentName='ds-networking-deployment'
 
 resource deploymentScript 'Microsoft.Resources/deploymentScripts@2020-10-01' = {
   name: 'ds-networking-deployment'
@@ -80,8 +81,12 @@ resource deploymentScript 'Microsoft.Resources/deploymentScripts@2020-10-01' = {
   }
 }
 
-output adminConsoleLBUrl string = length(lbSvcValues) > 0 && (reference('ds-networking-deployment').outputs.adminConsoleEndpoint != 'null') ? format('http://{0}/',reference('ds-networking-deployment').outputs.adminConsoleEndpoint): ''
-output adminServerT3LBUrl string = length(lbSvcValues) > 0 && (reference('ds-networking-deployment').outputs.adminServerT3Endpoint != 'null') ? reference('ds-networking-deployment').outputs.adminServerT3Endpoint: ''
-output clusterLBUrl string = length(lbSvcValues) > 0 && (reference('ds-networking-deployment').outputs.clusterEndpoint != 'null') ? format('http://{0}/',reference('ds-networking-deployment').outputs.clusterEndpoint): ''
-output clusterT3LBUrl string = length(lbSvcValues) > 0 && (reference('ds-networking-deployment').outputs.clusterT3Endpoint != 'null') ? reference('ds-networking-deployment').outputs.clusterT3Endpoint: ''
+output adminConsoleLBUrl string = (!enableCustomSSL) && length(lbSvcValues) > 0 && (reference(name_deploymentName).outputs.adminConsoleEndpoint != 'null') ? format('http://{0}/',reference(name_deploymentName).outputs.adminConsoleEndpoint): ''
+output adminConsoleLBSecuredUrl string = enableCustomSSL && length(lbSvcValues) > 0 && (reference(name_deploymentName).outputs.adminConsoleEndpoint != 'null') ? format('https://{0}/',reference(name_deploymentName).outputs.adminConsoleEndpoint): ''
+output adminServerT3LBUrl string = length(lbSvcValues) > 0 && (reference(name_deploymentName).outputs.adminServerT3Endpoint != 'null') ? reference(name_deploymentName).outputs.adminServerT3Endpoint: ''
+output adminRemoteUrl string = (!enableCustomSSL) && length(lbSvcValues) > 0 && (reference(name_deploymentName).outputs.adminRemoteEndpoint != 'null') ? format('http://{0}',reference(name_deploymentName).outputs.adminRemoteEndpoint): ''
+output adminRemoteSecuredUrl string = enableCustomSSL && length(lbSvcValues) > 0 && (reference(name_deploymentName).outputs.adminRemoteEndpoint != 'null') ? format('https://{0}',reference(name_deploymentName).outputs.adminRemoteEndpoint): ''
+output clusterLBUrl string = (!enableCustomSSL) && length(lbSvcValues) > 0 && (reference(name_deploymentName).outputs.clusterEndpoint != 'null') ? format('https://{0}/',reference(name_deploymentName).outputs.clusterEndpoint): ''
+output clusterLBSecuredUrl string = enableCustomSSL && length(lbSvcValues) > 0 && (reference(name_deploymentName).outputs.clusterEndpoint != 'null') ? format('http://{0}/',reference(name_deploymentName).outputs.clusterEndpoint): ''
+output clusterT3LBUrl string = length(lbSvcValues) > 0 && (reference(name_deploymentName).outputs.clusterT3Endpoint != 'null') ? reference(name_deploymentName).outputs.clusterT3Endpoint: ''
 

--- a/weblogic-azure-aks/src/main/bicep/modules/_deployment-scripts/_ds-query-storage-account.bicep
+++ b/weblogic-azure-aks/src/main/bicep/modules/_deployment-scripts/_ds-query-storage-account.bicep
@@ -6,9 +6,8 @@ param aksClusterRGName string = ''
 
 param identity object
 param utcValue string = utcNow()
-param wlsDomainUID string = 'sample-domain1'
 
-var const_arguments = '${aksClusterRGName} ${aksClusterName} ${wlsDomainUID}'
+var const_arguments = '${aksClusterRGName} ${aksClusterName}'
 var const_azcliVersion='2.15.0'
 var const_deploymentName='ds-query-storage-account'
 

--- a/weblogic-azure-aks/src/main/bicep/modules/networking.bicep
+++ b/weblogic-azure-aks/src/main/bicep/modules/networking.bicep
@@ -269,11 +269,11 @@ module pidNetworkingEnd './_pids/_pid.bicep' = {
   ]
 }
 
-output adminConsoleExternalUrl string = enableAppGWIngress ? (enableDNSConfiguration ? format('http://{0}console', const_appgwAdminCustomDNSAlias) : format('http://{0}/console', appgwDeployment.outputs.appGatewayAlias)) : networkingDeployment3.outputs.adminConsoleLBUrl
-output adminConsoleExternalSecuredUrl string = enableAppGWIngress && enableCustomSSL && enableDNSConfiguration ? format('https://{0}console', const_appgwAdminCustomDNSAlias) : ''
-output adminRemoteConsoleUrl string = enableAppGWIngress ? (enableDNSConfiguration ? format('http://{0}remoteconsole', const_appgwAdminCustomDNSAlias) : format('http://{0}/remoteconsole', appgwDeployment.outputs.appGatewayAlias)) : replace(networkingDeployment3.outputs.adminConsoleLBUrl, '/console/', '')
-output adminRemoteConsoleSecuredUrl string = enableAppGWIngress && enableCustomSSL && enableDNSConfiguration ? format('https://{0}remoteconsole', const_appgwAdminCustomDNSAlias) : ''
+output adminConsoleExternalUrl string = enableAppGWIngress ? (enableDNSConfiguration ? format('http://{0}console', const_appgwAdminCustomDNSAlias) : format('http://{0}/console', appgwDeployment.outputs.appGatewayAlias)) : ref_networkDeployment.outputs.adminConsoleLBUrl
+output adminConsoleExternalSecuredUrl string = enableAppGWIngress && enableCustomSSL && enableDNSConfiguration ? format('https://{0}console', const_appgwAdminCustomDNSAlias) : ref_networkDeployment.outputs.adminConsoleLBSecuredUrl
+output adminRemoteConsoleUrl string = enableAppGWIngress ? (enableDNSConfiguration ? format('http://{0}remoteconsole', const_appgwAdminCustomDNSAlias) : format('http://{0}/remoteconsole', appgwDeployment.outputs.appGatewayAlias)) : ref_networkDeployment.outputs.adminRemoteUrl
+output adminRemoteConsoleSecuredUrl string = enableAppGWIngress && enableCustomSSL && enableDNSConfiguration ? format('https://{0}remoteconsole', const_appgwAdminCustomDNSAlias) : ref_networkDeployment.outputs.adminRemoteSecuredUrl
 output adminServerT3ChannelUrl string = ref_networkDeployment.outputs.adminServerT3LBUrl.value
-output clusterExternalUrl string = enableAppGWIngress ? (enableDNSConfiguration ? format('http://{0}', const_appgwCustomDNSAlias) : appgwDeployment.outputs.appGatewayURL) : networkingDeployment3.outputs.clusterLBUrl
-output clusterExternalSecuredUrl string = enableAppGWIngress ? (enableDNSConfiguration ? format('https://{0}', const_appgwCustomDNSAlias) : appgwDeployment.outputs.appGatewaySecuredURL) : ''
+output clusterExternalUrl string = enableAppGWIngress ? (enableDNSConfiguration ? format('http://{0}', const_appgwCustomDNSAlias) : appgwDeployment.outputs.appGatewayURL) : ref_networkDeployment.outputs.clusterLBUrl
+output clusterExternalSecuredUrl string = enableAppGWIngress ? (enableDNSConfiguration ? format('https://{0}', const_appgwCustomDNSAlias) : appgwDeployment.outputs.appGatewaySecuredURL) : ref_networkDeployment.outputs.clusterLBSecuredUrl
 output clusterT3ChannelUrl string = ref_networkDeployment.outputs.clusterT3LBUrl.value

--- a/weblogic-azure-aks/src/main/bicep/modules/networking.bicep
+++ b/weblogic-azure-aks/src/main/bicep/modules/networking.bicep
@@ -271,7 +271,7 @@ module pidNetworkingEnd './_pids/_pid.bicep' = {
 
 output adminConsoleExternalUrl string = enableAppGWIngress ? (enableDNSConfiguration ? format('http://{0}console', const_appgwAdminCustomDNSAlias) : format('http://{0}/console', appgwDeployment.outputs.appGatewayAlias)) : networkingDeployment3.outputs.adminConsoleLBUrl
 output adminConsoleExternalSecuredUrl string = enableAppGWIngress && enableCustomSSL && enableDNSConfiguration ? format('https://{0}console', const_appgwAdminCustomDNSAlias) : ''
-output adminRemoteConsoleUrl string = enableAppGWIngress ? (enableDNSConfiguration ? format('http://{0}remoteconsole', const_appgwAdminCustomDNSAlias) : format('http://{0}/remoteconsole', appgwDeployment.outputs.appGatewayAlias)) : networkingDeployment3.outputs.adminConsoleLBUrl
+output adminRemoteConsoleUrl string = enableAppGWIngress ? (enableDNSConfiguration ? format('http://{0}remoteconsole', const_appgwAdminCustomDNSAlias) : format('http://{0}/remoteconsole', appgwDeployment.outputs.appGatewayAlias)) : replace(networkingDeployment3.outputs.adminConsoleLBUrl, '/console/', '')
 output adminRemoteConsoleSecuredUrl string = enableAppGWIngress && enableCustomSSL && enableDNSConfiguration ? format('https://{0}remoteconsole', const_appgwAdminCustomDNSAlias) : ''
 output adminServerT3ChannelUrl string = ref_networkDeployment.outputs.adminServerT3LBUrl.value
 output clusterExternalUrl string = enableAppGWIngress ? (enableDNSConfiguration ? format('http://{0}', const_appgwCustomDNSAlias) : appgwDeployment.outputs.appGatewayURL) : networkingDeployment3.outputs.clusterLBUrl

--- a/weblogic-azure-aks/src/main/bicep/modules/networking.bicep
+++ b/weblogic-azure-aks/src/main/bicep/modules/networking.bicep
@@ -269,11 +269,11 @@ module pidNetworkingEnd './_pids/_pid.bicep' = {
   ]
 }
 
-output adminConsoleExternalUrl string = enableAppGWIngress ? (enableDNSConfiguration ? format('http://{0}console', const_appgwAdminCustomDNSAlias) : format('http://{0}/console', appgwDeployment.outputs.appGatewayAlias)) : ref_networkDeployment.outputs.adminConsoleLBUrl
-output adminConsoleExternalSecuredUrl string = enableAppGWIngress && enableCustomSSL && enableDNSConfiguration ? format('https://{0}console', const_appgwAdminCustomDNSAlias) : ref_networkDeployment.outputs.adminConsoleLBSecuredUrl
-output adminRemoteConsoleUrl string = enableAppGWIngress ? (enableDNSConfiguration ? format('http://{0}remoteconsole', const_appgwAdminCustomDNSAlias) : format('http://{0}/remoteconsole', appgwDeployment.outputs.appGatewayAlias)) : ref_networkDeployment.outputs.adminRemoteUrl
-output adminRemoteConsoleSecuredUrl string = enableAppGWIngress && enableCustomSSL && enableDNSConfiguration ? format('https://{0}remoteconsole', const_appgwAdminCustomDNSAlias) : ref_networkDeployment.outputs.adminRemoteSecuredUrl
+output adminConsoleExternalUrl string = enableAppGWIngress ? (enableDNSConfiguration ? format('http://{0}console', const_appgwAdminCustomDNSAlias) : format('http://{0}/console', appgwDeployment.outputs.appGatewayAlias)) : ref_networkDeployment.outputs.adminConsoleLBUrl.value
+output adminConsoleExternalSecuredUrl string = enableAppGWIngress && enableCustomSSL && enableDNSConfiguration ? format('https://{0}console', const_appgwAdminCustomDNSAlias) : ref_networkDeployment.outputs.adminConsoleLBSecuredUrl.value
+output adminRemoteConsoleUrl string = enableAppGWIngress ? (enableDNSConfiguration ? format('http://{0}remoteconsole', const_appgwAdminCustomDNSAlias) : format('http://{0}/remoteconsole', appgwDeployment.outputs.appGatewayAlias)) : ref_networkDeployment.outputs.adminRemoteUrl.value
+output adminRemoteConsoleSecuredUrl string = enableAppGWIngress && enableCustomSSL && enableDNSConfiguration ? format('https://{0}remoteconsole', const_appgwAdminCustomDNSAlias) : ref_networkDeployment.outputs.adminRemoteSecuredUrl.value
 output adminServerT3ChannelUrl string = ref_networkDeployment.outputs.adminServerT3LBUrl.value
-output clusterExternalUrl string = enableAppGWIngress ? (enableDNSConfiguration ? format('http://{0}', const_appgwCustomDNSAlias) : appgwDeployment.outputs.appGatewayURL) : ref_networkDeployment.outputs.clusterLBUrl
-output clusterExternalSecuredUrl string = enableAppGWIngress ? (enableDNSConfiguration ? format('https://{0}', const_appgwCustomDNSAlias) : appgwDeployment.outputs.appGatewaySecuredURL) : ref_networkDeployment.outputs.clusterLBSecuredUrl
+output clusterExternalUrl string = enableAppGWIngress ? (enableDNSConfiguration ? format('http://{0}', const_appgwCustomDNSAlias) : appgwDeployment.outputs.appGatewayURL) : ref_networkDeployment.outputs.clusterLBUrl.value
+output clusterExternalSecuredUrl string = enableAppGWIngress ? (enableDNSConfiguration ? format('https://{0}', const_appgwCustomDNSAlias) : appgwDeployment.outputs.appGatewaySecuredURL) : ref_networkDeployment.outputs.clusterLBSecuredUrl.value
 output clusterT3ChannelUrl string = ref_networkDeployment.outputs.clusterT3LBUrl.value

--- a/weblogic-azure-aks/src/main/bicep/modules/updateWebLogicApplications.bicep
+++ b/weblogic-azure-aks/src/main/bicep/modules/updateWebLogicApplications.bicep
@@ -16,7 +16,7 @@ Parameters
   - aksClusterRGName: Name of resource group that contains the (AKS) instance, probably the resource group you are working on. It's recommended to run this sript with the same resource group that runs AKS.
   - aksClusterName: Name of the AKS instance that runs the WebLogic cluster.
   - appPackageUrls: String array of Java EE applciation location, which can be downloaded using "curl". Currently, only support urls of Azure Storage Account blob.
-  - appPackageFromStorageBlob: Storage blob that contains Java EE applciations, the script will download all the .war and .ear file from that blob. Do not include white space in the file name.
+  - appPackageFromStorageBlob: Storage blob that contains Java EE applciations, the script will download all the .war, .jar and .ear file from that blob. Do not include white space in the file name.
     - storageAccountName: Storage account name.
     - containerName: container name.
   - identity: Azure user managed identity used, make sure the identity has permission to create/update/delete Azure resources. It's recommended to assign "Contributor" role.
@@ -42,7 +42,7 @@ param aksClusterRGName string = ''
 @description('Name of an existing AKS cluster.')
 param aksClusterName string = ''
 
-@description('Download all the .war and .ear packages from the specified storage blob. You can specify the applciation using "appPackageUrls" and "appPackageFromStorageBlob", please do not specify the same applciation in both parameters.')
+@description('Download all the .war .jar and .ear packages from the specified storage blob. You can specify the applciation using "appPackageUrls" and "appPackageFromStorageBlob", please do not specify the same applciation in both parameters.')
 param appPackageFromStorageBlob object = {
   storageAccountName: 'stg-contoso'
   containerName: 'container-contoso'


### PR DESCRIPTION
This pr is for bug fixed which were found during the e2e test by the test vendors.

### **Changes:**
#### UI
- OSSO account password should not include semicolon.
- make nodeVM size number is the same with node count.
- fix regex of managed server prefix.
- enhance Lb editable grid with regex on service name prefix and port, no support on duplicated service prefix and duplicated targets.
- fix regex of app gateway frontend password.
- fix regex for "contains letters, numbers and hyphens (-), must begin with a letter, end with a letter or digit, and not contain consecutive hyphens".
- fix regex for db user name.
- enhance tooltip of DNS Zone name control.
- allow underscores (_), periods (.) and hyphens in jndi name.
#### Output
- remove `/console/` from the remote console url.
- output secured urls exposed by Lb service.
#### Scripts
- fix regression issue in post deployment introduced by t3 tunneling.
- fix issue - fail to create multiple domains in the sample cluster with SSL enabled.
- wait for ingress completed.
- support `.jar` package.