### PR TITLE
Support patched images

### DIFF
--- a/weblogic-azure-aks/pom.xml
+++ b/weblogic-azure-aks/pom.xml
@@ -11,7 +11,7 @@
 
   <groupId>com.oracle.weblogic.azure</groupId>
   <artifactId>wls-on-aks-azure-marketplace</artifactId>
-  <version>1.0.18</version>
+  <version>1.0.19</version>
 
   <parent>
     <groupId>com.microsoft.azure.iaas</groupId>

--- a/weblogic-azure-aks/src/main/arm/createUiDefinition.json
+++ b/weblogic-azure-aks/src/main/arm/createUiDefinition.json
@@ -67,47 +67,6 @@
                         "visible": true
                     },
                     {
-                        "name": "ocrSSOInfo",
-                        "type": "Microsoft.Common.InfoBox",
-                        "visible": true,
-                        "options": {
-                            "icon": "Info",
-                            "text": "Provide an Oracle Single Sign-On (SSO) account to access the Oracle Registry Server. Click the link to create Oracle SSO account.",
-                            "uri": "https://profile.oracle.com/myprofile/account/create-account.jspx"
-                        }
-                    },
-                    {
-                        "name": "ocrSSOUserName",
-                        "type": "Microsoft.Common.TextBox",
-                        "label": "Username for Oracle Single Sign-On authentication",
-                        "defaultValue": "example@contoso.com",
-                        "toolTip": "Username for Oracle Single Sign-On authentication to login the Oracle Container Registry.",
-                        "constraints": {
-                            "required": true,
-                            "regex": "^([a-zA-Z0-9_\\-\\.]+)@([a-zA-Z0-9_\\-\\.]+)\\.([a-zA-Z]{2,5})$",
-                            "validationMessage": "The value must be an email address."
-                        },
-                        "visible": true
-                    },
-                    {
-                        "name": "ocrSSOPassword",
-                        "type": "Microsoft.Common.PasswordBox",
-                        "label": {
-                            "password": "Password for Oracle Single Sign-On authentication",
-                            "confirmPassword": "Confirm password"
-                        },
-                        "toolTip": "Password for Oracle Single Sign-On authentication to login the Oracle Container Registry.",
-                        "constraints": {
-                            "required": true,
-                            "regex": "^(?=.*[A-Z])(?=.*[a-z])(?=.*\\d)[A-Za-z\\d\\$\\&\\+\\,:\\=\\?@#|'.\\^\\*!\\-_~/'\\[\\]\\{\\}\"]{8,}$",
-                            "validationMessage": "The password must contain at least 8 characters, with at least 1 uppercase letter, 1 lowercase letter and 1 number, and special characters, but should not contain > < ( ) % ; \\."
-                        },
-                        "options": {
-                            "hideConfirmation": false
-                        },
-                        "visible": true
-                    },
-                    {
                         "name": "errInfo",
                         "type": "Microsoft.Common.InfoBox",
                         "visible": "[less(length(basics('basicsRequired').identity.userAssignedIdentities),1)]",
@@ -393,13 +352,71 @@
                         ]
                     },
                     {
-                        "name": "acrInfo",
+                        "name": "imageInfo",
                         "type": "Microsoft.Common.Section",
-                        "label": "Azure Container Registry",
+                        "label": "Image Selection",
                         "elements": [
-                            {
-                                "name": "createACR",
+							{
+                                "name": "useOracleImage",
                                 "type": "Microsoft.Common.OptionsGroup",
+                                "label": "Use Oracle WebLogic Image?",
+                                "defaultValue": "Yes",
+                                "toolTip": "Select 'Yes' to Use Oracle WebLogic Image, or select 'No' to provide an existing image stored in ACR instance.",
+                                "constraints": {
+                                    "allowedValues": [
+                                        {
+                                            "label": "Yes",
+                                            "value": "true"
+                                        },
+                                        {
+                                            "label": "No",
+                                            "value": "false"
+                                        }
+                                    ],
+                                    "required": true
+                                }
+                            },
+                            {
+                                "name": "userProvidedAcrInfo",
+                                "type": "Microsoft.Common.InfoBox",
+                                "visible": "[not(bool(steps('section_aks').imageInfo.useOracleImage))]",
+                                "options": {
+                                    "icon": "Info",
+                                    "text": "Make sure the Azure Container Registry has enabled admin user.",
+                                    "uri": "https://docs.microsoft.com/en-us/azure/container-registry/container-registry-authentication#admin-account"
+                                }
+                            },
+                            {
+                                "name": "userProvidedAcrSelector",
+                                "type": "Microsoft.Solutions.ResourceSelector",
+                                "label": "Select existing ACR instance",
+                                "toolTip": "Select the existing ACR instance.",
+                                "resourceType": "Microsoft.ContainerRegistry/registries",
+                                "options": {
+                                    "filter": {
+                                        "subscription": "onBasics",
+                                        "location": "onBasics"
+                                    }
+                                },
+                                "visible": "[not(bool(steps('section_aks').imageInfo.useOracleImage))]"
+                            },
+                            {
+                                "name": "userProvidedImagePath",
+                                "type": "Microsoft.Common.TextBox",
+                                "visible": "[not(bool(steps('section_aks').imageInfo.useOracleImage))]",
+                                "label": "Please provide the image path",
+                                "toolTip": "Please provide the image path, the image must be stored in the selected ACR above",
+                                "defaultValue": "",
+                                "constraints": {
+                                    "required": "[not(bool(steps('section_aks').imageInfo.useOracleImage))]",
+                                    "regex": "[concat(coalesce(last(split(steps('section_aks').imageInfo.userProvidedAcrSelector.id, '/')), ''), '.*$')]",
+                                    "validationMessage": "The image must be stored in the selected ACR above"
+                                }
+                            },
+							{
+                                "name": "oracleCreateACR",
+                                "type": "Microsoft.Common.OptionsGroup",
+                                "visible": "[bool(steps('section_aks').imageInfo.useOracleImage)]",
                                 "label": "Create a new ACR instance?",
                                 "defaultValue": "Yes",
                                 "toolTip": "Select 'Yes' to create a new ACR instance, or select 'No' to provide an existing ACR instance.",
@@ -418,9 +435,9 @@
                                 }
                             },
                             {
-                                "name": "acrInfo",
+                                "name": "oracleAcrInfo",
                                 "type": "Microsoft.Common.InfoBox",
-                                "visible": "[not(bool(steps('section_aks').acrInfo.createACR))]",
+                                "visible": "[and(bool(steps('section_aks').imageInfo.useOracleImage),not(bool(steps('section_aks').imageInfo.oracleCreateACR)))]",
                                 "options": {
                                     "icon": "Info",
                                     "text": "Make sure the Azure Container Registry has enabled admin user.",
@@ -428,7 +445,7 @@
                                 }
                             },
                             {
-                                "name": "acrSelector",
+                                "name": "oracleAcrSelector",
                                 "type": "Microsoft.Solutions.ResourceSelector",
                                 "label": "Select ACR instance",
                                 "toolTip": "Select the existing ACR instance.",
@@ -439,19 +456,12 @@
                                         "location": "onBasics"
                                     }
                                 },
-                                "visible": "[not(bool(steps('section_aks').acrInfo.createACR))]"
-                            }
-                        ]
-                    },
-                    {
-                        "name": "imageInfo",
-                        "type": "Microsoft.Common.Section",
-                        "label": "Oracle WebLogic Image",
-                        "elements": [
+                                "visible": "[and(bool(steps('section_aks').imageInfo.useOracleImage),not(bool(steps('section_aks').imageInfo.oracleCreateACR)))]"
+                            },
                             {
                                 "name": "fromImageText",
                                 "type": "Microsoft.Common.TextBlock",
-                                "visible": true,
+                                "visible": "[bool(steps('section_aks').imageInfo.useOracleImage)]",
                                 "options": {
                                     "text": "This value is appended to 'container-registry.oracle.com/middleware/weblogic:' and used in the Dockerfile from statement. \nOracle Standard Terms and Restrictions terms must be agreed. \nClick the following link to make sure you have agree the terms and check the valid tags.",
                                     "link": {
@@ -461,11 +471,53 @@
                                 }
                             },
                             {
-                                "name": "fromImage",
+                                "name": "ocrSSOInfo",
+                                "type": "Microsoft.Common.InfoBox",
+                                "visible": "[bool(steps('section_aks').imageInfo.useOracleImage)]",
+                                "options": {
+                                    "icon": "Info",
+                                    "text": "Provide an Oracle Single Sign-On (SSO) account to access the Oracle Registry Server. Click the link to create Oracle SSO account.",
+                                    "uri": "https://profile.oracle.com/myprofile/account/create-account.jspx"
+                                }
+                            },
+                            {
+                                "name": "ocrSSOUserName",
                                 "type": "Microsoft.Common.TextBox",
+                                "label": "Username for Oracle Single Sign-On authentication",
+                                "defaultValue": "example@contoso.com",
+                                "toolTip": "Username for Oracle Single Sign-On authentication to login the Oracle Container Registry.",
+                                "constraints": {
+                                    "required": true,
+                                    "regex": "^([a-zA-Z0-9_\\-\\.]+)@([a-zA-Z0-9_\\-\\.]+)\\.([a-zA-Z]{2,5})$",
+                                    "validationMessage": "The value must be an email address."
+                                },
+                                "visible": "[bool(steps('section_aks').imageInfo.useOracleImage)]"
+                            },
+                            {
+                                "name": "ocrSSOPassword",
+                                "type": "Microsoft.Common.PasswordBox",
+                                "label": {
+                                    "password": "Password for Oracle Single Sign-On authentication",
+                                    "confirmPassword": "Confirm password"
+                                },
+                                "toolTip": "Password for Oracle Single Sign-On authentication to login the Oracle Container Registry.",
+                                "constraints": {
+                                    "required": true,
+                                    "regex": "^(?=.*[A-Z])(?=.*[a-z])(?=.*\\d)[A-Za-z\\d\\$\\&\\+\\,:\\=\\?@#|'.\\^\\*!\\-_~/'\\[\\]\\{\\}\"]{8,}$",
+                                    "validationMessage": "The password must contain at least 8 characters, with at least 1 uppercase letter, 1 lowercase letter and 1 number, and special characters, but should not contain > < ( ) % ; \\."
+                                },
+                                "options": {
+                                    "hideConfirmation": false
+                                },
+                                "visible": "[bool(steps('section_aks').imageInfo.useOracleImage)]"
+                            },
+                            {
+                                "name": "fromOracleImage",
+                                "type": "Microsoft.Common.TextBox",
+                                "visible": "[bool(steps('section_aks').imageInfo.useOracleImage)]",
                                 "label": "WebLogic Docker tag",
                                 "defaultValue": "12.2.1.4-ol8",
-                                "toolTip": "Docker tag that comes after 'container-registry.oracle.com/middleware/weblogic:' in the fromImage option to 'imagetool'.",
+                                "toolTip": "Docker tag that comes after 'container-registry.oracle.com/middleware/weblogic:' in the fromOracleImage option to 'imagetool'.",
                                 "multiLine": false,
                                 "constraints": {
                                     "required": true,
@@ -1651,7 +1703,7 @@
             }
         ],
         "outputs": {
-            "acrName": "[last(split(steps('section_aks').acrInfo.acrSelector.id, '/'))]",
+            "acrName": "[last(split(steps('section_aks').imageInfo.oracleAcrSelector.id, '/'))]",
             "aksAgentPoolNodeCount": "[steps('section_aks').clusterInfo.aksNodeCount]",
             "aksClusterName": "[last(split(steps('section_aks').clusterInfo.aksClusterSelector.id, '/'))]",
             "aksClusterRGName": "[last(take(split(steps('section_aks').clusterInfo.aksClusterSelector.id, '/'), 5))]",
@@ -1663,7 +1715,7 @@
             "appgwForRemoteConsole": "[steps('section_appGateway').appgwIngress.appgwForAdminRemote]",
             "appPackageUrls": "[steps('section_aks').jeeAppInfo.appPackageUrl]",
             "appReplicas": "[int(steps('section_aks').jeeAppInfo.appReplicas)]",
-            "createACR": "[bool(steps('section_aks').acrInfo.createACR)]",
+            "createACR": "[bool(steps('section_aks').imageInfo.oracleCreateACR)]",
             "createAKSCluster": "[bool(steps('section_aks').clusterInfo.createAKSCluster)]",
             "createDNSZone": "[not(bool(steps('section_dnsConfiguration').bringDNSZone))]",
             "dbPassword": "[steps('section_database').databaseConnectionInfo.dbPassword]",
@@ -1695,8 +1747,8 @@
             "keyVaultSSLCertDataSecretName": "[steps('section_appGateway').appgwIngress.keyVaultSSLCertDataSecretName]",
             "keyVaultSSLCertPasswordSecretName": "[steps('section_appGateway').appgwIngress.keyVaultSSLCertPasswordSecretName]",
             "managedServerPrefix": "[basics('basicsOptional').managedServerPrefix]",
-            "ocrSSOPSW": "[basics('basicsRequired').ocrSSOPassword]",
-            "ocrSSOUser": "[basics('basicsRequired').ocrSSOUserName]",
+            "ocrSSOPSW": "[steps('section_aks').imageInfo.ocrSSOPassword]",
+            "ocrSSOUser": "[steps('section_aks').imageInfo.ocrSSOUserName]",
             "servicePrincipal": "[steps('section_appGateway').appgwIngress.servicePrincipal]",
             "sslConfigurationAccessOption": "[steps('section_sslConfiguration').sslConfigurationAccessOption]",
             "sslKeyVaultCustomIdentityKeyStoreDataSecretName": "[steps('section_sslConfiguration').keyVaultStoredCustomSSLSettings.keyVaultCustomIdentityKeyStoreDataSecretName]",
@@ -1718,11 +1770,14 @@
             "sslUploadedPrivateKeyAlias": "[steps('section_sslConfiguration').uploadedCustomSSLSettings.uploadedPrivateKeyAlias]",
             "sslUploadedPrivateKeyPassPhrase": "[steps('section_sslConfiguration').uploadedCustomSSLSettings.uploadedPrivateKeyPassPhrase]",
             "useInternalLB": "[bool(steps('section_appGateway').lbSVCInfo.enableInternalLB)]",
+            "useOracleImage": "[bool(steps('section_aks').imageInfo.useOracleImage)]",
+            "userProvidedAcr": "[last(split(steps('section_aks').imageInfo.userProvidedAcrSelector.id, '/'))]",
+			"userProvidedImagePath": "[steps('section_aks').imageInfo.userProvidedImagePath]",
             "wdtRuntimePassword": "[basics('basicsRequired').wdtRuntimePassword]",
             "wlsClusterSize": "[basics('basicsOptional').wlsClusterSize]",
             "wlsDomainName": "[basics('basicsOptional').wlsDomainName]",
             "wlsDomainUID": "[basics('basicsOptional').wlsDomainUID]",
-            "wlsImageTag": "[steps('section_aks').imageInfo.fromImage]",
+            "wlsImageTag": "[steps('section_aks').imageInfo.fromOracleImage]",
             "wlsJavaOption": "[basics('basicsOptional').wlsJavaOption]",
             "wlsPassword": "[basics('basicsRequired').wlsPassword]",
             "wlsUserName": "[basics('basicsRequired').wlsUserName]"

--- a/weblogic-azure-aks/src/main/arm/createUiDefinition.json
+++ b/weblogic-azure-aks/src/main/arm/createUiDefinition.json
@@ -359,9 +359,9 @@
 							{
                                 "name": "useOracleImage",
                                 "type": "Microsoft.Common.OptionsGroup",
-                                "label": "Use Oracle WebLogic Image?",
+                                "label": "Use a pre-existing WebLogic Server Docker image in Oracle Container Registry?",
                                 "defaultValue": "Yes",
-                                "toolTip": "Select 'Yes' to Use Oracle WebLogic Image, or select 'No' to provide an existing image stored in ACR instance.",
+                                "toolTip": "Select 'Yes' to a use pre-existing WebLogic Server Docker image from the public Oracle Container Registry. Select 'No' to use a pre-existing Docker image, assumed to be a compatible WebLogic server image, from the specified ACR instance. This allows the use of custom PSU images.",
                                 "constraints": {
                                     "allowedValues": [
                                         {

--- a/weblogic-azure-aks/src/main/arm/scripts/invokeSetupWLSDomain.sh
+++ b/weblogic-azure-aks/src/main/arm/scripts/invokeSetupWLSDomain.sh
@@ -42,6 +42,8 @@ Usage:
     <t3AdminPort>
     <t3ClusterPort>
     <wlsJavaOption>
+    <userProvidedImagePath>
+    <useOracleImage>
 END
 )
     echo_stdout "${usage}"
@@ -92,6 +94,8 @@ export enableClusterT3Tunneling=${32}
 export t3AdminPort=${33}
 export t3ClusterPort=${34}
 export wlsJavaOption=${35}
+export userProvidedImagePath=${36}
+export useOracleImage=${37}
 
 echo ${ocrSSOPSW} \
     ${wlsPassword} \
@@ -128,7 +132,9 @@ echo ${ocrSSOPSW} \
     ${enableClusterT3Tunneling} \
     ${t3AdminPort} \
     ${t3ClusterPort} \
-    ${wlsJavaOption}
+    ${wlsJavaOption} \
+    ${userProvidedImagePath} \
+    ${useOracleImage}
 
 if [ $? -ne 0 ]; then
     usage 1

--- a/weblogic-azure-aks/src/main/arm/scripts/invokeUpdateApplications.sh
+++ b/weblogic-azure-aks/src/main/arm/scripts/invokeUpdateApplications.sh
@@ -20,6 +20,8 @@ Usage:
     <scriptURL>
     <appStorageAccountName>
     <appContainerName>
+    <userProvidedImagePath>
+    <useOracleImage>
 END
 )
     echo_stdout "${usage}"
@@ -48,6 +50,8 @@ export appPackageUrls=${10}
 export scriptURL=${11}
 export appStorageAccountName=${12}
 export appContainerName=${13}
+export userProvidedImagePath=${14}
+export useOracleImage=${15}
 
 echo ${ocrSSOPSW} | \
     bash ./updateApplications.sh \
@@ -62,7 +66,9 @@ echo ${ocrSSOPSW} | \
     ${appPackageUrls} \
     ${scriptURL} \
     ${appStorageAccountName} \
-    ${appContainerName}
+    ${appContainerName} \
+    ${userProvidedImagePath} \
+    ${useOracleImage}
 
 if [ $? -ne 0 ]; then
     usage 1

--- a/weblogic-azure-aks/src/main/arm/scripts/setupWLSDomain.sh
+++ b/weblogic-azure-aks/src/main/arm/scripts/setupWLSDomain.sh
@@ -44,6 +44,8 @@ echo <ocrSSOPSW> <wlsPassword> <wdtRuntimePassword> <wlsIdentityPsw> <wlsIdentit
     <enableClusterT3Tunneling>
     <t3AdminPort>
     <t3ClusterPort>
+    <userProvidedImagePath>
+    <useOracleImage>
 END
     )
     echo_stdout ${usage}
@@ -55,7 +57,12 @@ END
 
 #Function to validate input
 function validate_input() {
-    if [[ -z "$ocrSSOUser" || -z "${ocrSSOPSW}" ]]; then
+    if [ -z "$useOracleImage" ]; then
+        echo_stderr "userProvidedImagePath is required. "
+        usage 1
+    fi
+
+    if [[ "${useOracleImage,,}" == "${constTrue}" ]] && [[ -z "$ocrSSOUser" || -z "${ocrSSOPSW}" ]]; then
         echo_stderr "Oracle SSO account is required. "
         usage 1
     fi
@@ -207,6 +214,11 @@ function validate_input() {
 
     if [[ "${wlsJavaOption}" == "null" ]];then
         wlsJavaOption=""
+    fi
+
+    if [[ "${useOracleImage,,}" == "${constFalse}" ]] && [ -z "$userProvidedImagePath" ]; then
+        echo_stderr "userProvidedImagePath is required. "
+        usage 1
     fi
 }
 
@@ -369,7 +381,9 @@ function build_docker_image() {
             $enableCustomSSL \
             "$scriptURL" \
             ${enableAdminT3Tunneling} \
-            ${enableClusterT3Tunneling}
+            ${enableClusterT3Tunneling} \
+            ${useOracleImage} \
+            ${userProvidedImagePath}
 
     az acr repository show -n ${acrName} --image aks-wls-images:${newImageTag}
     if [ $? -ne 0 ]; then
@@ -786,6 +800,8 @@ export enableClusterT3Tunneling=${26}
 export t3AdminPort=${27}
 export t3ClusterPort=${28}
 export wlsJavaOption=${29}
+export userProvidedImagePath=${30}
+export useOracleImage=${31}
 
 export adminServerName="admin-server"
 export azFileShareName="weblogic"

--- a/weblogic-azure-aks/src/main/arm/scripts/updateApplications.sh
+++ b/weblogic-azure-aks/src/main/arm/scripts/updateApplications.sh
@@ -25,6 +25,8 @@ echo <ocrSSOPSW> |
     <scriptURL>
     <appStorageAccountName>
     <appContainerName>
+    <userProvidedImagePath>
+    <useOracleImage>
 END
 )
     echo_stdout "${usage}"
@@ -36,7 +38,12 @@ END
 
 #Function to validate input
 function validate_input() {
-    if [[ -z "$ocrSSOUser" || -z "${ocrSSOPSW}" ]]; then
+    if [ -z "$useOracleImage" ]; then
+        echo_stderr "userProvidedImagePath is required. "
+        usage 1
+    fi
+
+    if [[ "${useOracleImage,,}" == "${constTrue}" ]] && [[ -z "$ocrSSOUser" || -z "${ocrSSOPSW}" ]]; then
         echo_stderr "Oracle SSO account is required. "
         usage 1
     fi
@@ -88,6 +95,11 @@ function validate_input() {
 
     if [ -z "$appContainerName" ]; then
         echo_stderr "appContainerName is required. "
+        usage 1
+    fi
+
+    if [[ "${useOracleImage,,}" == "${constFalse}" ]] && [ -z "$userProvidedImagePath" ]; then
+        echo_stderr "userProvidedImagePath is required. "
         usage 1
     fi
 }
@@ -214,7 +226,9 @@ function build_docker_image() {
         $enableCustomSSL \
         "$scriptURL" \
         ${enableAdminT3} \
-        ${enableClusterT3}
+        ${enableClusterT3} \
+        ${useOracleImage} \
+        ${userProvidedImagePath}
 
     az acr repository show -n ${acrName} --image aks-wls-images:${newImageTag}
     if [ $? -ne 0 ]; then
@@ -289,6 +303,8 @@ export appPackageUrls=$9
 export scriptURL=${10}
 export appStorageAccountName=${11}
 export appContainerName=${12}
+export userProvidedImagePath=${13}
+export useOracleImage=${14}
 
 export newImageTag=$(date +%s)
 # seconds

--- a/weblogic-azure-aks/src/main/bicep/mainTemplate.bicep
+++ b/weblogic-azure-aks/src/main/bicep/mainTemplate.bicep
@@ -290,7 +290,7 @@ module pids './modules/_pids/_pid.bicep' = {
 // Due to lack of preprocessor solution for the way we use bicep, must hard-code the pid here.
 // For test, replace the pid with testing one, and build the package.
 module partnerCenterPid './modules/_pids/_empty.bicep' = {
-  name: 'pid-a1775ed4-512c-4cfa-9e68-f0b09b36de90-partnercenter'
+  name: 'pid-cf7143e4-83ed-4b7e-ae86-1c5ecdd71bcb-partnercenter'
 }
 
 module wlsSSLCertSecretsDeployment 'modules/_azure-resoruces/_keyvault/_keyvaultForWLSSSLCert.bicep' = if (enableCustomSSL && sslConfigurationAccessOption != const_wlsSSLCertOptionKeyVault) {

--- a/weblogic-azure-aks/src/main/bicep/mainTemplate.bicep
+++ b/weblogic-azure-aks/src/main/bicep/mainTemplate.bicep
@@ -143,9 +143,9 @@ param lbSvcValues array = []
 param managedServerPrefix string = 'managed-server'
 @secure()
 @description('Password of Oracle SSO account.')
-param ocrSSOPSW string
+param ocrSSOPSW string = newGuid()
 @description('User name of Oracle SSO account.')
-param ocrSSOUser string
+param ocrSSOUser string = 'null'
 @secure()
 @description('Base64 string of service principal. use the command to generate a testing string: az ad sp create-for-rbac --sdk-auth | base64 -w0')
 param servicePrincipal string = newGuid()
@@ -218,6 +218,12 @@ param t3ChannelClusterPort int = 8011
 param useInternalLB bool = false
 @description('ture to upload Java EE applications and deploy the applications to WebLogic domain.')
 param utcValue string = utcNow()
+@description('User provided ACR for base image')
+param userProvidedAcr string = 'null'
+@description('User provided base image path')
+param userProvidedImagePath string = 'null'
+@description('Use Oracle images or user provided patched images')
+param useOracleImage bool = true
 @secure()
 @description('Password for model WebLogic Deploy Tooling runtime encrytion.')
 param wdtRuntimePassword string
@@ -364,6 +370,9 @@ module wlsDomainDeployment 'modules/setupWebLogicCluster.bicep' = if (!enableCus
     t3ChannelAdminPort: t3ChannelAdminPort
     t3ChannelClusterPort: t3ChannelClusterPort
     wdtRuntimePassword: wdtRuntimePassword
+    userProvidedAcr: userProvidedAcr
+    userProvidedImagePath: userProvidedImagePath
+    useOracleImage: useOracleImage
     wlsClusterSize: wlsClusterSize
     wlsCPU: wlsCPU
     wlsDomainName: wlsDomainName
@@ -424,6 +433,9 @@ module wlsDomainWithCustomSSLDeployment 'modules/setupWebLogicCluster.bicep' = i
     storageAccountName: name_storageAccountName
     t3ChannelAdminPort: t3ChannelAdminPort
     t3ChannelClusterPort: t3ChannelClusterPort
+    userProvidedAcr: userProvidedAcr
+    userProvidedImagePath: userProvidedImagePath
+    useOracleImage: useOracleImage
     wdtRuntimePassword: wdtRuntimePassword
     wlsClusterSize: wlsClusterSize
     wlsCPU: wlsCPU

--- a/weblogic-azure-aks/src/main/bicep/modules/_deployment-scripts/_ds-create-networking.bicep
+++ b/weblogic-azure-aks/src/main/bicep/modules/_deployment-scripts/_ds-create-networking.bicep
@@ -89,4 +89,3 @@ output adminRemoteSecuredUrl string = enableCustomSSL && length(lbSvcValues) > 0
 output clusterLBUrl string = (!enableCustomSSL) && length(lbSvcValues) > 0 && (reference(name_deploymentName).outputs.clusterEndpoint != 'null') ? format('https://{0}/',reference(name_deploymentName).outputs.clusterEndpoint): ''
 output clusterLBSecuredUrl string = enableCustomSSL && length(lbSvcValues) > 0 && (reference(name_deploymentName).outputs.clusterEndpoint != 'null') ? format('http://{0}/',reference(name_deploymentName).outputs.clusterEndpoint): ''
 output clusterT3LBUrl string = length(lbSvcValues) > 0 && (reference(name_deploymentName).outputs.clusterT3Endpoint != 'null') ? reference(name_deploymentName).outputs.clusterT3Endpoint: ''
-

--- a/weblogic-azure-aks/src/main/bicep/modules/_deployment-scripts/_ds-create-wls-cluster.bicep
+++ b/weblogic-azure-aks/src/main/bicep/modules/_deployment-scripts/_ds-create-wls-cluster.bicep
@@ -24,6 +24,8 @@ param storageAccountName string = 'null'
 param t3ChannelAdminPort int = 7005
 param t3ChannelClusterPort int = 8011
 param utcValue string = utcNow()
+param userProvidedImagePath string = 'null'
+param useOracleImage bool = true
 @secure()
 param wdtRuntimePassword string
 param wlsClusterSize int = 5
@@ -56,7 +58,7 @@ param wlsTrustKeyStorePassPhrase string = newGuid()
 param wlsTrustKeyStoreType string = 'PKCS12'
 param wlsUserName string = 'weblogic'
 
-var const_arguments = '${ocrSSOUser} ${ocrSSOPSW} ${aksClusterRGName} ${aksClusterName} ${wlsImageTag} ${acrName} ${wlsDomainName} ${wlsDomainUID} ${wlsUserName} ${wlsPassword} ${wdtRuntimePassword} ${wlsCPU} ${wlsMemory} ${managedServerPrefix} ${appReplicas} ${string(appPackageUrls)} ${resourceGroup().name} ${const_scriptLocation} ${storageAccountName} ${wlsClusterSize} ${enableCustomSSL} ${wlsIdentityKeyStoreData} ${wlsIdentityKeyStorePassphrase} ${wlsIdentityKeyStoreType} ${wlsPrivateKeyAlias} ${wlsPrivateKeyPassPhrase} ${wlsTrustKeyStoreData} ${wlsTrustKeyStorePassPhrase} ${wlsTrustKeyStoreType} ${enablePV} ${enableAdminT3Tunneling} ${enableClusterT3Tunneling} ${t3ChannelAdminPort} ${t3ChannelClusterPort} "${wlsJavaOption}"'
+var const_arguments = '${ocrSSOUser} ${ocrSSOPSW} ${aksClusterRGName} ${aksClusterName} ${wlsImageTag} ${acrName} ${wlsDomainName} ${wlsDomainUID} ${wlsUserName} ${wlsPassword} ${wdtRuntimePassword} ${wlsCPU} ${wlsMemory} ${managedServerPrefix} ${appReplicas} ${string(appPackageUrls)} ${resourceGroup().name} ${const_scriptLocation} ${storageAccountName} ${wlsClusterSize} ${enableCustomSSL} ${wlsIdentityKeyStoreData} ${wlsIdentityKeyStorePassphrase} ${wlsIdentityKeyStoreType} ${wlsPrivateKeyAlias} ${wlsPrivateKeyPassPhrase} ${wlsTrustKeyStoreData} ${wlsTrustKeyStorePassPhrase} ${wlsTrustKeyStoreType} ${enablePV} ${enableAdminT3Tunneling} ${enableClusterT3Tunneling} ${t3ChannelAdminPort} ${t3ChannelClusterPort} "${wlsJavaOption}" ${userProvidedImagePath} ${useOracleImage}'
 var const_buildDockerImageScript='createVMAndBuildImage.sh'
 var const_commonScript = 'common.sh'
 var const_invokeSetUpDomainScript = 'invokeSetupWLSDomain.sh'

--- a/weblogic-azure-aks/src/main/bicep/modules/_deployment-scripts/_ds_update-applications.bicep
+++ b/weblogic-azure-aks/src/main/bicep/modules/_deployment-scripts/_ds_update-applications.bicep
@@ -23,8 +23,10 @@ param utcValue string = utcNow()
 param wlsDomainName string = 'domain1'
 param wlsDomainUID string = 'sample-domain1'
 param wlsImageTag string = '12.2.1.4'
+param userProvidedImagePath string = 'null'
+param useOracleImage bool = true
 
-var const_arguments = '${ocrSSOUser} ${ocrSSOPSW} ${aksClusterRGName} ${aksClusterName} ${wlsImageTag} ${acrName} ${wlsDomainName} ${wlsDomainUID} ${resourceGroup().name} ${string(appPackageUrls)} ${const_scriptLocation} ${appPackageFromStorageBlob.storageAccountName} ${appPackageFromStorageBlob.containerName} '
+var const_arguments = '${ocrSSOUser} ${ocrSSOPSW} ${aksClusterRGName} ${aksClusterName} ${wlsImageTag} ${acrName} ${wlsDomainName} ${wlsDomainUID} ${resourceGroup().name} ${string(appPackageUrls)} ${const_scriptLocation} ${appPackageFromStorageBlob.storageAccountName} ${appPackageFromStorageBlob.containerName} ${userProvidedImagePath} ${useOracleImage} '
 var const_azcliVersion='2.15.0'
 var const_buildDockerImageScript='createVMAndBuildImage.sh'
 var const_commonScript = 'common.sh'

--- a/weblogic-azure-aks/src/main/bicep/modules/setupWebLogicCluster.bicep
+++ b/weblogic-azure-aks/src/main/bicep/modules/setupWebLogicCluster.bicep
@@ -73,6 +73,9 @@ param ocrSSOUser string
 param storageAccountName string
 param t3ChannelAdminPort int = 7005
 param t3ChannelClusterPort int = 8011
+param userProvidedAcr string = 'null'
+param userProvidedImagePath string = 'null'
+param useOracleImage bool = true
 @secure()
 @description('Password for model WebLogic Deploy Tooling runtime encrytion.')
 param wdtRuntimePassword string
@@ -150,7 +153,7 @@ module aksClusterDeployment './_azure-resoruces/_aks.bicep' = if (createAKSClust
 /*
 * Deploy ACR
 */
-module acrDeployment './_azure-resoruces/_acr.bicep' = if (createACR) {
+module acrDeployment './_azure-resoruces/_acr.bicep' = if (useOracleImage && createACR) {
   name: 'acr-deployment'
   params: {
     location: location
@@ -182,7 +185,7 @@ module wlsDomainDeployment './_deployment-scripts/_ds-create-wls-cluster.bicep' 
     _artifactsLocationSasToken: _artifactsLocationSasToken
     aksClusterRGName: createAKSCluster ? resourceGroup().name : aksClusterRGName
     aksClusterName: createAKSCluster ? aksClusterDeployment.outputs.aksClusterName : aksClusterName
-    acrName: createACR ? acrDeployment.outputs.acrName : acrName
+    acrName: useOracleImage ? (createACR ? acrDeployment.outputs.acrName : acrName) : userProvidedAcr
     appPackageUrls: appPackageUrls
     appReplicas: appReplicas
     enableCustomSSL: enableCustomSSL
@@ -197,6 +200,8 @@ module wlsDomainDeployment './_deployment-scripts/_ds-create-wls-cluster.bicep' 
     storageAccountName: storageAccountName
     t3ChannelAdminPort: t3ChannelAdminPort
     t3ChannelClusterPort: t3ChannelClusterPort
+    userProvidedImagePath: userProvidedImagePath
+    useOracleImage: useOracleImage
     wdtRuntimePassword: wdtRuntimePassword
     wlsClusterSize: wlsClusterSize
     wlsCPU: wlsCPU

--- a/weblogic-azure-aks/src/main/bicep/modules/updateWebLogicApplications.bicep
+++ b/weblogic-azure-aks/src/main/bicep/modules/updateWebLogicApplications.bicep
@@ -54,9 +54,9 @@ param identity object
 
 @secure()
 @description('Password of Oracle SSO account.')
-param ocrSSOPSW string
+param ocrSSOPSW string = 'null'
 @description('User name of Oracle SSO account.')
-param ocrSSOUser string
+param ocrSSOUser string = 'null'
 
 @description('Name of WebLogic domain to create.')
 param wlsDomainName string = 'domain1'
@@ -64,6 +64,12 @@ param wlsDomainName string = 'domain1'
 param wlsDomainUID string = 'sample-domain1'
 @description('Docker tag that comes after "container-registry.oracle.com/middleware/weblogic:"')
 param wlsImageTag string = '12.2.1.4'
+@description('User provided ACR for base image')
+param userProvidedAcr string = 'null'
+@description('User provided base image path')
+param userProvidedImagePath string = 'null'
+@description('Use Oracle images or user provided patched images')
+param useOracleImage bool = true
 
 module pids './_pids/_pid.bicep' = {
   name: 'initialization'
@@ -86,7 +92,7 @@ module updateWLSApplications '_deployment-scripts/_ds_update-applications.bicep'
     _artifactsLocationSasToken: _artifactsLocationSasToken
     aksClusterRGName: aksClusterRGName
     aksClusterName: aksClusterName
-    acrName: acrName
+    acrName: useOracleImage ? acrName : userProvidedAcr
     appPackageUrls: appPackageUrls
     appPackageFromStorageBlob: appPackageFromStorageBlob
     identity: identity
@@ -95,6 +101,8 @@ module updateWLSApplications '_deployment-scripts/_ds_update-applications.bicep'
     wlsDomainName: wlsDomainName
     wlsDomainUID: wlsDomainUID
     wlsImageTag: wlsImageTag
+    userProvidedImagePath: userProvidedImagePath
+    useOracleImage: useOracleImage
   }
   dependsOn:[
     pidStart


### PR DESCRIPTION
**Update UI**: Add additional selection choice to allow user deploy offer with provided patched image(stored in Azure Container Registry)
![image](https://user-images.githubusercontent.com/74032668/134840257-a99ccd4c-2a95-4e13-8daf-9d66e4f4bd40.png)
**Update templates and scripts**: Support patched image for WLS on AKS creation, Application & Configuration update.
**Update PID and pom version**:  Currently using PID from [test plan](https://portal.azure.com/#create/microsoft_javaeeonazure_test.20210108-galia-previewzheng-wls-aks-cluster), increased pom version to 1.0.19

Test cases:
* Deploy WLS on AKS with Application Gateway and testwebapp using patched image (WebLogic 12)
* Update existing WLS on AKS with shoppingcart and patched image (WebLogic 14)
* Create WLS on AKS using Oracle Image
