### PR TITLE
On branch edburns-msft-46-fix-trivial-python-error use str. Tested locally.

### DIFF
--- a/weblogic-azure-aks/src/main/arm/scripts/py-scripts/checkApplicationStatus.py
+++ b/weblogic-azure-aks/src/main/arm/scripts/py-scripts/checkApplicationStatus.py
@@ -55,4 +55,4 @@ for app in myapps:
 if inactiveApp == 0:
     print("Summary: all applications are active!")
 else:
-    print("Summary: number of inactive application:" + inactiveApp + '.')
+    print("Summary: number of inactive application: " + str(inactiveApp) + '.')


### PR DESCRIPTION


modified:   weblogic-azure-aks/src/main/arm/scripts/py-scripts/checkApplicationStatus.py

With fix:

```
python message.py
Summary: number of inactive application:0.
```

Without fix:

```
python message.py
Traceback (most recent call last):
  File "message.py", line 3, in <module>
    print("Summary: number of inactive application: " + inactiveApp + '.')
TypeError: cannot concatenate 'str' and 'int' objects
```

Signed-off-by: Ed Burns <edburns@microsoft.com>