### PR TITLE
Use Git token to sync up with upstream

### DIFF
--- a/.github/workflows/syncupWithUpstream.yml
+++ b/.github/workflows/syncupWithUpstream.yml
@@ -1,18 +1,20 @@
 name: Merge upstream branches
 on:
   workflow_dispatch:
-  schedule:
-    # run it every 10 mins
-    - cron:  '*/10 * * * *'
+  repository_dispatch:
+    types: [upstream-sync]
 env:
   userName: ${{ secrets.USER_NAME }}
   userEmail: ${{ secrets.USER_EMAIL }}
+  gitToken: ${{ secrets.GIT_TOKEN }}
 jobs:
   merge:
     if: (github.event_name == 'schedule' && github.repository_owner == 'mriccell') || (github.event_name != 'schedule')
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2
+        with:
+          token: ${{ env.gitToken }}
       - name: Merge upstream
         run: |
           git config --global user.name ${{ env.userName }}


### PR DESCRIPTION
* Remove scheduled runs
* Use Git token to enable full permissions
* Use repository_dispatch so the pipeline can be triggered using following commands:
`curl --verbose -X POST https://api.github.com/repos/mriccell/weblogic-azure/dispatches -H 'Accept: application/vnd.github.everest-preview+json' -H 'Authorization: token <replace with git token> --data '{"event_type": "upstream-sync"}'`

Signed-off-by: Zheng Chang <zhengchang@microsoft.com>