### PR TITLE
Apply resources limits to wls 14.1.1.0 to solve the evicted pod issue.

### DIFF
--- a/weblogic-azure-aks/pom.xml
+++ b/weblogic-azure-aks/pom.xml
@@ -17,7 +17,7 @@
 
   <groupId>com.oracle.weblogic.azure</groupId>
   <artifactId>wls-on-aks-azure-marketplace</artifactId>
-  <version>1.0.29</version>
+  <version>1.0.30</version>
 
   <parent>
     <groupId>com.microsoft.azure.iaas</groupId>

--- a/weblogic-azure-aks/src/main/arm/scripts/applyGuaranteedQos.sh
+++ b/weblogic-azure-aks/src/main/arm/scripts/applyGuaranteedQos.sh
@@ -100,7 +100,7 @@ spec:
     introspectorJobActiveDeadlineSeconds: ${constIntrospectorJobActiveDeadlineSeconds}
   restartVersion: "${restartVersion}"
 EOF
-    echo_stdout "New resrouces configurations: "
+    echo_stdout "New resource configurations: "
     echo_stdout $(cat patch-resource-limits.yaml)
     # patch the domain with resource limits
     kubectl -n ${wlsDomainNS} patch domain ${WLS_DOMAIN_UID} \
@@ -110,7 +110,7 @@ EOF
     # make sure all of the pods are running correctly.
     replicas=$(kubectl -n ${wlsDomainNS} get domain ${WLS_DOMAIN_UID} -o json |
         jq '. | .spec.clusters[] | .replicas')
-    # pod provision will be slower as the resources is limited, set larger max attemp.
+    # pod provision will be slower, set larger max attemp.
     maxAttemps=$((checkPodStatusMaxAttemps * 2))
     interval=$((checkPodStatusInterval * 2))
 

--- a/weblogic-azure-aks/src/main/arm/scripts/applyGuaranteedQos.sh
+++ b/weblogic-azure-aks/src/main/arm/scripts/applyGuaranteedQos.sh
@@ -2,6 +2,7 @@
 # Licensed under the Universal Permissive License v 1.0 as shown at https://oss.oracle.com/licenses/upl.
 # This script runs on Azure Container Instance with Alpine Linux that Azure Deployment script creates.
 #
+# Temporary workaround for https://github.com/oracle/weblogic-kubernetes-operator/issues/2693
 # env inputs:
 # AKS_CLUSTER_NAME
 # AKS_CLUSTER_RESOURCEGROUP_NAME

--- a/weblogic-azure-aks/src/main/arm/scripts/applyGuaranteedQos.sh
+++ b/weblogic-azure-aks/src/main/arm/scripts/applyGuaranteedQos.sh
@@ -1,0 +1,137 @@
+# Copyright (c) 2021, Oracle Corporation and/or its affiliates.
+# Licensed under the Universal Permissive License v 1.0 as shown at https://oss.oracle.com/licenses/upl.
+# This script runs on Azure Container Instance with Alpine Linux that Azure Deployment script creates.
+#
+# env inputs:
+# AKS_CLUSTER_NAME
+# AKS_CLUSTER_RESOURCEGROUP_NAME
+# WLS_DOMAIN_UID
+
+# Main script
+script="${BASH_SOURCE[0]}"
+scriptDir="$(cd "$(dirname "${script}")" && pwd)"
+source ${scriptDir}/common.sh
+source ${scriptDir}/utility.sh
+
+qualityofService="BestEffort"
+wlsContainerName="weblogic-server"
+wlsDomainNS="${WLS_DOMAIN_UID}-ns"
+
+echo_stdout "install kubectl"
+install_kubectl
+
+echo_stdout "Connect AKS"
+az aks get-credentials \
+    --resource-group ${AKS_CLUSTER_RESOURCEGROUP_NAME} \
+    --name ${AKS_CLUSTER_NAME} \
+    --overwrite-existing
+
+adminPodName=$(kubectl -n ${wlsDomainNS} get pod -l weblogic.serverName=admin-server -o json |
+    jq '.items[0] | .metadata.name' |
+    tr -d "\"")
+if [ -z "${adminPodName}" ]; then
+    echo_stderr "Fail to get admin server pod."
+    exit 1
+fi
+
+wlstQueryVersionScript=queryVersion.py
+cat <<EOF >${wlstQueryVersionScript}
+print '#version#:' + version
+EOF
+
+echo_stdout "copy WLST script ${wlstQueryVersionScript} to ${adminPodName}:/tmp/${wlstQueryVersionScript}"
+targetPyFilePath=/tmp/${wlstQueryVersionScript}
+kubectl cp ${wlstQueryVersionScript} -n ${wlsDomainNS} ${adminPodName}:${targetPyFilePath}
+version=$(kubectl exec -it ${adminPodName} -n ${wlsDomainNS} -c ${wlsContainerName} -- bash -c "wlst.sh ${targetPyFilePath}")
+# output sample:
+# Initializing WebLogic Scripting Tool (WLST) ...
+
+# Welcome to WebLogic Server Administration Scripting Shell
+
+# Type help() for help on available commands
+
+# #version#:WebLogic Server 14.1.1.0.0
+version="${version##*\#version\#\:}" # match #version#:, this is a special mark for the version output, please do not change it.
+echo_stdout ${version}
+
+if [ "${version#*WebLogic Server 14.1.1.0}" != "$version" ]; then
+    timestampBeforePatchingDomain=$(date +%s)
+    echo  "timestampBeforePatchingDomain=${timestampBeforePatchingDomain}"
+    
+    # we assume the customer to create WebLogic Server using the offer or template,
+    # and specify the same resources requirement for admin server and managed server.
+    cpuRequest=$(kubectl get domain ${WLS_DOMAIN_UID} -n ${wlsDomainNS} -o json |
+        jq '. |.spec.serverPod.resources.requests.cpu' |
+        tr -d "\"")
+    echo_stdout "Previous CPU request: ${cpuRequest}"
+
+    memoryRequest=$(kubectl get domain ${WLS_DOMAIN_UID} -n ${wlsDomainNS} -o json |
+        jq '. | .spec.serverPod.resources.requests.memory' |
+        tr -d "\"")
+    echo_stdout "Previous memory request: ${memoryRequest}"
+
+    restartVersion=$(kubectl -n ${wlsDomainNS} get domain ${WLS_DOMAIN_UID} -o json |
+        jq '. | .spec.restartVersion' |
+        tr -d "\"")
+    restartVersion=$((restartVersion+1))
+
+    # check CPU units, set units with "m"
+    if [[ ${cpuRequest} =~ "m" ]]; then
+        cpu=$(echo $cpuRequest | sed 's/[^0-9]*//g')
+    else
+        cpu=$((cpuRequest * 1000))
+    fi
+    # make sure there is enough CPU limits to run the WebLogic Server
+    # if the cpu is less than 500m, set it 500m
+    # the domain configuration will be outputed after the offer deployment finishes.
+    if [ $cpu -lt 500 ]; then
+        cpu=500
+    fi
+
+    # create patch configuration with YAML file
+    # keep resources.limits the same with requests
+    cat <<EOF >patch-resource-limits.yaml
+spec:
+  serverPod:
+    resources: 
+      requests:
+        cpu: "${cpu}m"
+        memory: "${memoryRequest}"
+      limits:
+        cpu: "${cpu}m"
+        memory: "${memoryRequest}"
+  configuration: 
+    introspectorJobActiveDeadlineSeconds: ${constIntrospectorJobActiveDeadlineSeconds}
+  restartVersion: "${restartVersion}"
+EOF
+    echo_stdout "New resrouces configurations: "
+    echo_stdout $(cat patch-resource-limits.yaml)
+    # patch the domain with resource limits
+    kubectl -n ${wlsDomainNS} patch domain ${WLS_DOMAIN_UID} \
+        --type=merge \
+        --patch "$(cat patch-resource-limits.yaml)"
+
+    # make sure all of the pods are running correctly.
+    replicas=$(kubectl -n ${wlsDomainNS} get domain ${WLS_DOMAIN_UID} -o json |
+        jq '. | .spec.clusters[] | .replicas')
+    # pod provision will be slower as the resources is limited, set larger max attemp.
+    maxAttemps=$((checkPodStatusMaxAttemps * 2))
+    interval=$((checkPodStatusInterval * 2))
+
+    utility_wait_for_pod_restarted \
+        ${timestampBeforePatchingDomain} \
+        ${replicas} \
+        "${WLS_DOMAIN_UID}" \
+        ${maxAttemps} \
+        ${interval}
+
+    qualityofService="Guaranteed"
+fi
+
+# output the WebLogic Server version and quality of service.
+result=$(jq -n -c \
+    --arg wlsVersion "$version" \
+    --arg qualityofService "$qualityofService" \
+    '{wlsVersion: $wlsVersion, qualityofService: $qualityofService}')
+echo "result is: $result"
+echo $result >$AZ_SCRIPTS_OUTPUT_PATH

--- a/weblogic-azure-aks/src/main/arm/scripts/common.sh
+++ b/weblogic-azure-aks/src/main/arm/scripts/common.sh
@@ -10,7 +10,7 @@ export constAdminServerName='admin-server'
 export constClusterName='cluster-1'
 export constClusterT3AddressEnvName="T3_TUNNELING_CLUSTER_ADDRESS"
 export constDefaultJavaOptions="-Dlog4j2.formatMsgNoLookups=true -Dweblogic.StdoutDebugEnabled=false" # the java options will be applied to the cluster
-export constDefaultJVMArgs="-Djava.security.egd=file:/dev/./urandom -XX:MinRAMPercentage=25.0 -XX:MaxRAMPercentage=50.0 " # the JVM options will be applied to the cluster
+export constDefaultJVMArgs="-Djava.security.egd=file:/dev/./urandom -Xms256m -Xmx512m -XX:MinRAMPercentage=25.0 -XX:MaxRAMPercentage=50.0 " # the JVM options will be applied to the cluster
 export constFalse="false"
 export constTrue="true"
 export constIntrospectorJobActiveDeadlineSeconds=300  # for Guaranteed Qos

--- a/weblogic-azure-aks/src/main/arm/scripts/common.sh
+++ b/weblogic-azure-aks/src/main/arm/scripts/common.sh
@@ -10,8 +10,10 @@ export constAdminServerName='admin-server'
 export constClusterName='cluster-1'
 export constClusterT3AddressEnvName="T3_TUNNELING_CLUSTER_ADDRESS"
 export constDefaultJavaOptions="-Dlog4j2.formatMsgNoLookups=true -Dweblogic.StdoutDebugEnabled=false" # the java options will be applied to the cluster
+export constDefaultJVMArgs="-Djava.security.egd=file:/dev/./urandom -XX:MinRAMPercentage=25.0 -XX:MaxRAMPercentage=50.0 " # the JVM options will be applied to the cluster
 export constFalse="false"
 export constTrue="true"
+export constIntrospectorJobActiveDeadlineSeconds=300  # for Guaranteed Qos
 
 export curlMaxTime=120 # seconds
 export ocrLoginServer="container-registry.oracle.com"

--- a/weblogic-azure-aks/src/main/arm/scripts/genDomainConfig.sh
+++ b/weblogic-azure-aks/src/main/arm/scripts/genDomainConfig.sh
@@ -90,7 +90,7 @@ spec:
     - name: JAVA_OPTIONS
       value: "${constDefaultJavaOptions} ${javaOptions}"
     - name: USER_MEM_ARGS
-      value: "-Djava.security.egd=file:/dev/./urandom -Xms256m -Xmx512m -XX:MinRAMPercentage=25.0 -XX:MaxRAMPercentage=50.0 "
+      value: "${constDefaultJVMArgs}"
     - name: MANAGED_SERVER_PREFIX
       value: "${wlsManagedPrefix}"
 EOF

--- a/weblogic-azure-aks/src/main/bicep/mainTemplate.bicep
+++ b/weblogic-azure-aks/src/main/bicep/mainTemplate.bicep
@@ -647,6 +647,27 @@ module datasourceDeployment 'modules/_setupDBConnection.bicep' = if (enableDB) {
 }
 
 /*
+* Apply resource limits to WebLogic Server 14c.
+* The script will check the WebLogic Server version, and apply resource limits to 14c.
+* The resource limits will be the same with requests.
+*/
+module applyGuaranteedQos 'modules/_deployment-scripts/_ds-apply-guaranteed-qos.bicep' = {
+  name: 'apply-resources-limits-to-wls14'
+  params:{
+    _artifactsLocation: _artifactsLocation
+    _artifactsLocationSasToken: _artifactsLocationSasToken
+    aksClusterRGName: ref_wlsDomainDeployment.outputs.aksClusterRGName.value
+    aksClusterName: ref_wlsDomainDeployment.outputs.aksClusterName.value
+    identity: identity
+    location: location
+    wlsDomainUID: wlsDomainUID
+  }
+  dependsOn: [
+    datasourceDeployment
+  ]
+}
+
+/*
 * To check if all the applciations in WLS cluster become ACTIVE state after all configurations are completed.
 * This should be the last step.
 */
@@ -664,7 +685,7 @@ module validateApplciations 'modules/_deployment-scripts/_ds-validate-applicatio
     wlsUserName: wlsUserName
   }
   dependsOn: [
-    datasourceDeployment
+    applyGuaranteedQos
   ]
 }
 

--- a/weblogic-azure-aks/src/main/bicep/mainTemplate.bicep
+++ b/weblogic-azure-aks/src/main/bicep/mainTemplate.bicep
@@ -647,6 +647,7 @@ module datasourceDeployment 'modules/_setupDBConnection.bicep' = if (enableDB) {
 }
 
 /*
+* Temporary workaround for https://github.com/oracle/weblogic-kubernetes-operator/issues/2693
 * Apply resource limits to WebLogic Server 14.1.1.0.
 * The script will check the WebLogic Server version, and apply resource limits to 14.1.1.0.
 * The resource limits will be the same with requests.

--- a/weblogic-azure-aks/src/main/bicep/mainTemplate.bicep
+++ b/weblogic-azure-aks/src/main/bicep/mainTemplate.bicep
@@ -276,6 +276,7 @@ var const_hasStorageAccount = !createAKSCluster && reference('query-existing-sto
 var const_identityKeyStoreType = (sslConfigurationAccessOption == const_wlsSSLCertOptionKeyVault) ? sslKeyVaultCustomIdentityKeyStoreType : sslUploadedCustomIdentityKeyStoreType
 var const_keyvaultNameFromTag = const_hasTags && contains(resourceGroup().tags, name_tagNameForKeyVault) ? resourceGroup().tags.wlsKeyVault : ''
 var const_trustKeyStoreType = (sslConfigurationAccessOption == const_wlsSSLCertOptionKeyVault) ? sslKeyVaultCustomTrustKeyStoreType : sslUploadedCustomTrustKeyStoreType
+var const_wlsClusterName = 'cluster-1'
 var const_wlsJavaOptions = wlsJavaOption == '' ? 'null' : wlsJavaOption
 var const_wlsSSLCertOptionKeyVault = 'keyVaultStoredConfig'
 var name_defaultPidDeployment = 'pid'
@@ -661,6 +662,7 @@ module applyGuaranteedQos 'modules/_deployment-scripts/_ds-apply-guaranteed-qos.
     aksClusterName: ref_wlsDomainDeployment.outputs.aksClusterName.value
     identity: identity
     location: location
+    wlsClusterName: const_wlsClusterName
     wlsDomainUID: wlsDomainUID
   }
   dependsOn: [

--- a/weblogic-azure-aks/src/main/bicep/mainTemplate.bicep
+++ b/weblogic-azure-aks/src/main/bicep/mainTemplate.bicep
@@ -647,8 +647,8 @@ module datasourceDeployment 'modules/_setupDBConnection.bicep' = if (enableDB) {
 }
 
 /*
-* Apply resource limits to WebLogic Server 14c.
-* The script will check the WebLogic Server version, and apply resource limits to 14c.
+* Apply resource limits to WebLogic Server 14.1.1.0.
+* The script will check the WebLogic Server version, and apply resource limits to 14.1.1.0.
 * The resource limits will be the same with requests.
 */
 module applyGuaranteedQos 'modules/_deployment-scripts/_ds-apply-guaranteed-qos.bicep' = {

--- a/weblogic-azure-aks/src/main/bicep/modules/_deployment-scripts/_ds-apply-guaranteed-qos.bicep
+++ b/weblogic-azure-aks/src/main/bicep/modules/_deployment-scripts/_ds-apply-guaranteed-qos.bicep
@@ -1,0 +1,62 @@
+// Copyright (c) 2021, Oracle Corporation and/or its affiliates.
+// Licensed under the Universal Permissive License v 1.0 as shown at https://oss.oracle.com/licenses/upl.
+
+/* This script is to apply Guaranteed Qos by specifying resources.limits
+*  To solve pod evicted issue in Oracle WebLogic 14c.
+*  The script will promote CPU request and limit to 500m if the CPU request is less than 500m.
+*/
+
+param _artifactsLocation string = deployment().properties.templateLink.uri
+@secure()
+param _artifactsLocationSasToken string = ''
+
+param aksClusterName string = ''
+param aksClusterRGName string = ''
+
+param identity object
+param location string
+param utcValue string = utcNow()
+
+param wlsDomainUID string = 'sample-domain1'
+
+var const_azcliVersion = '2.15.0'
+var const_constScript = 'common.sh'
+var const_deploymentName = 'ds-apply-guaranteed-qos'
+var const_scriptLocation = uri(_artifactsLocation, 'scripts/')
+var const_updateQosScript = 'applyGuaranteedQos.sh'
+var const_utilityScript = 'utility.sh'
+
+resource deploymentScript 'Microsoft.Resources/deploymentScripts@2020-10-01' = {
+  name: const_deploymentName
+  location: location
+  kind: 'AzureCLI'
+  identity: identity
+  properties: {
+    azCliVersion: const_azcliVersion
+    environmentVariables: [
+      {
+        name: 'AKS_CLUSTER_NAME'
+        value: aksClusterName
+      }
+      {
+        name: 'AKS_CLUSTER_RESOURCEGROUP_NAME'
+        value: aksClusterRGName
+      }
+      {
+        name: 'WLS_DOMAIN_UID'
+        value: wlsDomainUID
+      }
+    ]
+    primaryScriptUri: uri(const_scriptLocation, '${const_updateQosScript}${_artifactsLocationSasToken}')
+    supportingScriptUris: [
+      uri(const_scriptLocation, '${const_constScript}${_artifactsLocationSasToken}')
+      uri(const_scriptLocation, '${const_utilityScript}${_artifactsLocationSasToken}')
+    ]
+    cleanupPreference: 'OnSuccess'
+    retentionInterval: 'P1D'
+    forceUpdateTag: utcValue
+  }
+}
+
+output wlsVersion string = string(reference(const_deploymentName).outputs.wlsVersion)
+output qualityofService string = string(reference(const_deploymentName).outputs.qualityofService)

--- a/weblogic-azure-aks/src/main/bicep/modules/_deployment-scripts/_ds-apply-guaranteed-qos.bicep
+++ b/weblogic-azure-aks/src/main/bicep/modules/_deployment-scripts/_ds-apply-guaranteed-qos.bicep
@@ -2,7 +2,7 @@
 // Licensed under the Universal Permissive License v 1.0 as shown at https://oss.oracle.com/licenses/upl.
 
 /* This script is to apply Guaranteed Qos by specifying resources.limits
-*  To solve pod evicted issue in Oracle WebLogic 14c.
+*  To solve pod evicted issue in Oracle WebLogic 14.1.1.0.
 *  The script will promote CPU request and limit to 500m if the CPU request is less than 500m.
 */
 

--- a/weblogic-azure-aks/src/main/bicep/modules/_deployment-scripts/_ds-apply-guaranteed-qos.bicep
+++ b/weblogic-azure-aks/src/main/bicep/modules/_deployment-scripts/_ds-apply-guaranteed-qos.bicep
@@ -16,7 +16,7 @@ param aksClusterRGName string = ''
 param identity object
 param location string
 param utcValue string = utcNow()
-
+param wlsClusterName string = 'cluster-1'
 param wlsDomainUID string = 'sample-domain1'
 
 var const_azcliVersion = '2.15.0'
@@ -41,6 +41,10 @@ resource deploymentScript 'Microsoft.Resources/deploymentScripts@2020-10-01' = {
       {
         name: 'AKS_CLUSTER_RESOURCEGROUP_NAME'
         value: aksClusterRGName
+      }
+      {
+        name: 'WLS_CLUSTER_NAME'
+        value: wlsClusterName
       }
       {
         name: 'WLS_DOMAIN_UID'


### PR DESCRIPTION
### Description
This pr is a workaround for the evicted issue on WLS 14c.  We have discussion on this [Slack thread](https://oracle-weblogic.slack.com/archives/CE3M9DGSY/p1636965419023600)

The WLS14c admin pod become evicted at age 2/3 days with error like `Container weblogic-server was using 3300040Ki, which exceeds its request of 1610612736.` 

The admin pod used memory more than the request studently, see the monitoring screenshot
![memory-usage](https://user-images.githubusercontent.com/59823457/147523693-c69eeda7-d068-499a-8e86-909d7adab86e.png)
I am working with Anil to find out the root cause.

Per our observation, applying the resources.limits can resolve the issue, we decided to apply the settings by default.
As the issue does not happen to 12c, so we agree to only apply to 14c, otherwise it will cause the deployment slower. 


### Test

Test on WLS14c: https://github.com/galiacheng/weblogic-azure/actions/runs/1628854471
Test on WLS 12c: 
![image](https://user-images.githubusercontent.com/59823457/147542596-62963f59-aad1-48ac-81a6-9871d945a7d6.png)
