### PR TITLE
On branch edburns-msft-dd-1460785-cpu_registry-mapping-file …

### DIFF
--- a/weblogic-azure-aks/src/main/resources/weblogic_cpu_images.json
+++ b/weblogic-azure-aks/src/main/resources/weblogic_cpu_images.json
@@ -1,0 +1,38 @@
+{
+    "name": "Oracle WebLogic Server docker image tags mapping for Azure Marketplace offer",
+    "description": "List image tag mapping from Oracle Container Registry middleware/weblogic and middleware/weblogic_cpu repository.",
+    "items": [
+        {
+            "gaTag": "14.1.1.0-11",
+            "cpuTag": "14.1.1.0-generic-jdk11-ol7"
+        },
+        {
+            "gaTag": "14.1.1.0-11-ol8",
+            "cpuTag": "14.1.1.0-generic-jdk11-ol8"
+        },
+        {
+            "gaTag": "14.1.1.0-8",
+            "cpuTag": "14.1.1.0-generic-jdk8-ol7"
+        },
+        {
+            "gaTag": "14.1.1.0-8-ol8",
+            "cpuTag": "14.1.1.0-generic-jdk8-ol8"
+        },
+        {
+            "gaTag": "12.2.1.4",
+            "cpuTag": "12.2.1.4-generic-jdk8-ol7"
+        },
+        {
+            "gaTag": "12.2.1.4-ol8",
+            "cpuTag": "12.2.1.4-generic-jdk8-ol8"
+        },
+        {
+            "gaTag": "12.2.1.3",
+            "cpuTag": "12.2.1.3-generic-jdk8-ol7"
+        },
+        {
+            "gaTag": "12.2.1.3-ol8",
+            "cpuTag": "12.2.1.3-generic-jdk8-ol8"
+        }
+    ]
+}


### PR DESCRIPTION
This file contains the mappings used to allow the correct CPU vs GA tag to be used.

new file:   weblogic-azure-aks/src/main/resources/weblogic_cpu_images.json

Signed-off-by: Ed Burns <edburns@microsoft.com>