### PR TITLE
Updated CICD workflow files and scripts

### DIFF
--- a/.github/workflows/testWlsVmCluster.yml
+++ b/.github/workflows/testWlsVmCluster.yml
@@ -289,13 +289,6 @@ jobs:
           sed -i "s/#adminPasswordOrKey#/$wlsPassword/g" \
           ${{ env.offerPath }}/test/scripts/verify-wls-path.sh
 
-          sed -i "s/#adminVMName#/$adminVMName/g; \
-          s/#adminPasswordOrKey#/$wlsPassword/g; \
-          s/#managedServers#/$managedServers/g; \
-          s/#wlsUserName#/$wlsUserName/g; \
-          s/#wlspassword#/$wlsPassword/g" \
-          ${{ env.offerPath }}/test/scripts/verify-servers-lifecycle.sh
-
       - name: Accept Image Terms
         id: accept-terms
         run: |
@@ -403,6 +396,15 @@ jobs:
         id: env-managedserver-vm1-ip
         run: echo "ms1PublicIP=${{steps.query-wls-managed-ip.outputs.publicIP}}" >> $GITHUB_ENV
 
+
+      # Fix failure that caused by remote server closed.
+      - name: Restart remote SSH agent
+        run: |
+            echo "Restart remote SSH agent"
+            az vm user reset-ssh \
+              --resource-group $resourceGroup \
+              --name ${{ env.adminVMName }}
+
       - name: Verify WebLogic Server Installation
         id: verify-wls
         run: |
@@ -412,14 +414,6 @@ jobs:
           echo install sshpass
           sudo apt-get install -y sshpass
           sshpass -p ${wlsPassword} -v ssh -p 22 -o StrictHostKeyChecking=no -o ConnectTimeout=100 -v -tt weblogic@${wlsPublicIP} 'bash -s' < ${{ env.offerPath }}/test/scripts/verify-wls-path.sh
-
-      # Fix failure that caused by remote server closed.
-      - name: Restart remote SSH agent
-        run: |
-            echo "Restart remote SSH agent"
-            az vm user reset-ssh \
-              --resource-group $resourceGroup \
-              --name ${{ env.adminVMName }}
 
       - name: Verify wls admin services
         id: veriy-admin-service
@@ -451,21 +445,13 @@ jobs:
           echo "Verifying Weblogic Server Access"
           bash ${{ env.offerPath }}/test/scripts/verify-wls-access.sh <<< "$wlsPublicIP ${adminConsolePort} $wlsUserName $wlsPassword $managedServers"
 
-      # Fix failure that caused by remote server closed.
-      - name: Restart remote SSH agent
-        run: |
-            echo "Restart remote SSH agent"
-            az vm user reset-ssh \
-              --resource-group $resourceGroup \
-              --name ${{ env.adminVMName }}
-
       - name: Verify WebLogic Managed Server LifeCycle check
         id: verify-server-lifecycle
         run: |
           echo "wait for port 22"
           timeout 6m sh -c 'until nc -zv $0 $1; do echo "nc rc: $?"; sleep 5; done' ${wlsPublicIP} 22
           echo "Verifying Weblogic managed server lifecycle"
-          sshpass -p ${wlsPassword} -v ssh -p 22 -o StrictHostKeyChecking=no -o ConnectTimeout=100 -v -tt weblogic@${wlsPublicIP} 'bash -s' < ${{ env.offerPath }}/test/scripts/verify-servers-lifecycle.sh
+          bash ${{ env.offerPath }}/test/scripts/verify-servers-lifecycle.sh <<< "$wlsUserName $wlsPassword ${wlsPublicIP} ${adminConsolePort} ${managedServers}"
 
       - name: Deploy DB Template to Connect to Azure Postgresql Database
         id: enable-postgresql-db
@@ -570,19 +556,6 @@ jobs:
           echo "adminVMDNS=${{steps.query-adminvmdns.outputs.adminVMDNS}}" >> $GITHUB_ENV
           echo ${adminVMDNS}
 
-      - name: Prepare the webapp deployment script
-        id: prepare-webapp-deployement-script
-        run: |
-          echo ${adminVMDNS} ${wlsUserName}
-          sed -i "s/#adminVMDNS#/${adminVMDNS}/g; \
-              s/#wlsUserName#/$wlsUserName/g; \
-              s/#wlsPassword#/$wlsPassword/g" \
-              ${{ env.offerPath }}/test/scripts/deploy-webapp.sh
-
-          echo ${appGatewayURL}
-          sed -i "s|#appGatewayURL#|${appGatewayURL}|g;" \
-              ${{ env.offerPath }}/test/scripts/verify-webapp-deployment.sh
-
       - name: Add ip address to security rule to access the wls machine
         id: add-ip-to-security-rule-105
         run: |
@@ -636,13 +609,13 @@ jobs:
         run: |
           echo "Deploy WebLogic Cafe to server"          
           timeout 6m sh -c 'until nc -zv $0 $1; do echo "nc rc: $?"; sleep 5; done' ${adminVMDNS} ${adminConsolePort}
-          bash ${{ env.offerPath }}/test/scripts/deploy-webapp.sh
+          bash ${{ env.offerPath }}/test/scripts/deploy-webapp.sh <<< "$wlsUserName $wlsPassword ${adminVMDNS} ${adminConsolePort} "
 
       - name: Verify WebLogicCafe app is successfully deployed
         id: verify-webapp-deployment
         run: |
           echo "Verify WebLogicCafe app is successfully deployed"
-          bash ${{ env.offerPath }}/test/scripts/verify-webapp-deployment.sh
+          bash ${{ env.offerPath }}/test/scripts/verify-webapp-deployment.sh <<< "${appGatewayURL}"
 
       - name: Set up ELK by deploying sub template
         id: enable-elk
@@ -877,9 +850,9 @@ jobs:
         run: |
           curl -XDELETE --user ${{ env.elkUser }}:${{ env.elkPassword }}  ${{ env.elkURI }}/azure-weblogic-cluster-${{ github.run_id }}${{ github.run_number }}
 
-  cleanup-github-resoruce:
+  cleanup-github-resource:
     needs: deploy-weblogic-cluster
-    if: success()
+    if: always()
     runs-on: ubuntu-latest
     steps:
       - name: Checkout ${{ env.repoName }}

--- a/.github/workflows/testWlsVmDynamicCluster.yml
+++ b/.github/workflows/testWlsVmDynamicCluster.yml
@@ -276,14 +276,9 @@ jobs:
         id: prepare-deployed-parameters-and-test-script
         run: |
           imageUrn="${{ matrix.images }}"
+
           sed -i "s/#adminPasswordOrKey#/$wlsPassword/g" \
-          ${offerPath}/test/scripts/verify-wls-path.sh
-          sed -i "s/#adminVMName#/$adminVMName/g; \
-          s/#adminPasswordOrKey#/$wlsPassword/g; \
-          s/#managedServers#/$managedServers/g; \
-          s/#wlsUserName#/$wlsUserName/g; \
-          s/#wlspassword#/$wlsPassword/g" \
-          ${offerPath}/test/scripts/verify-servers-lifecycle.sh
+          ${{ env.offerPath }}/test/scripts/verify-wls-path.sh
 
           echo "Generate deployment parameters..."
           bash ${offerPath}/test/scripts/gen-parameters-deploy.sh <<< \
@@ -390,6 +385,7 @@ jobs:
               --name $adminVMName -d \
               --query publicIps -o tsv)
             echo "##[set-output name=publicIP;]${publicIP}"
+            
       - name: Create environment variable for AdminServer IP
         id: env-admin-ip
         run: echo "wlsPublicIP=${{steps.query-wls-admin-ip.outputs.publicIP}}" >> $GITHUB_ENV
@@ -407,6 +403,14 @@ jobs:
         id: env-managedserver-vm1-ip
         run: echo "ms1PublicIP=${{steps.query-wls-managed-ip.outputs.publicIP}}" >> $GITHUB_ENV
 
+      # Fix failure that caused by remote server closed.
+      - name: Restart remote SSH agent
+        run: |
+            echo "Restart remote SSH agent"
+            az vm user reset-ssh \
+              --resource-group $resourceGroup \
+              --name ${{ env.adminVMName }}
+
       - name: Verify WebLogic Server Installation
         id: verify-wls
         run: |
@@ -416,14 +420,6 @@ jobs:
           echo install sshpass
           sudo apt-get install -y sshpass
           sshpass -p ${wlsPassword} -v ssh -p 22 -o StrictHostKeyChecking=no -o ConnectTimeout=100 -v -tt weblogic@${wlsPublicIP} 'bash -s' < ${offerPath}/test/scripts/verify-wls-path.sh
-
-      # Fix failure that caused by remote server closed.
-      - name: Restart remote SSH agent
-        run: |
-            echo "Restart remote SSH agent"
-            az vm user reset-ssh \
-              --resource-group $resourceGroup \
-              --name ${{ env.adminVMName }}
 
       - name: Verify wls admin services
         id: veriy-admin-service
@@ -455,21 +451,12 @@ jobs:
           echo "Verifying Weblogic Server Access"
           bash ${offerPath}/test/scripts/verify-wls-access.sh <<< "$wlsPublicIP ${adminConsolePort} $wlsUserName $wlsPassword $managedServers"
 
-      # Fix failure that caused by remote server closed.
-      - name: Restart remote SSH agent
-        run: |
-            echo "Restart remote SSH agent"
-            az vm user reset-ssh \
-              --resource-group $resourceGroup \
-              --name ${{ env.adminVMName }}
-
       - name: Verify WebLogic Managed Server LifeCycle check
         id: verify-server-lifecycle
         run: |
           echo "wait for port 22"
-          timeout 6m sh -c 'until nc -zv $0 $1; do echo "nc rc: $?"; sleep 5; done' ${wlsPublicIP} 22
           echo "Verifying Weblogic managed server lifecycle"
-          sshpass -p ${wlsPassword} -v ssh -p 22 -o StrictHostKeyChecking=no -o ConnectTimeout=100 -v -tt weblogic@${wlsPublicIP} 'bash -s' < ${offerPath}/test/scripts/verify-servers-lifecycle.sh
+          bash ${offerPath}/test/scripts/verify-servers-lifecycle.sh <<< "$wlsUserName $wlsPassword ${wlsPublicIP} ${adminConsolePort} ${managedServers}"
 
       - name: Deploy DB Template to Connect to Azure Postgresql Database
         id: enable-postgresql-db

--- a/weblogic-azure-vm/arm-oraclelinux-wls-cluster/test/data/parameters-test.json
+++ b/weblogic-azure-vm/arm-oraclelinux-wls-cluster/test/data/parameters-test.json
@@ -30,7 +30,7 @@
       "value": "#adminvmname#"
     },
     "vmSizeSelect": {
-      "value": "Standard_D2as_v4"
+      "value": "Standard_B2ms"
     },
     "location": {
       "value": "#location#"

--- a/weblogic-azure-vm/arm-oraclelinux-wls-cluster/test/scripts/gen-parameters-aad-ag.sh
+++ b/weblogic-azure-vm/arm-oraclelinux-wls-cluster/test/scripts/gen-parameters-aad-ag.sh
@@ -59,7 +59,7 @@ cat <<EOF > ${parametersPath}
             "value": 4
         },
         "vmSizeSelect": {
-            "value": "Standard_D2as_v4"
+            "value": "Standard_B2ms"
         },
         "wlsLDAPGroupBaseDN": {
             "value": "GEN-UNIQUE"

--- a/weblogic-azure-vm/arm-oraclelinux-wls-cluster/test/scripts/gen-parameters-aad.sh
+++ b/weblogic-azure-vm/arm-oraclelinux-wls-cluster/test/scripts/gen-parameters-aad.sh
@@ -47,7 +47,7 @@ cat <<EOF > ${parametersPath}
             "value": 4
         },
         "vmSizeSelect": {
-            "value": "Standard_D2as_v4"
+            "value": "Standard_B2ms"
         },
         "wlsLDAPGroupBaseDN": {
             "value": "GEN-UNIQUE"

--- a/weblogic-azure-vm/arm-oraclelinux-wls-cluster/test/scripts/gen-parameters-ag.sh
+++ b/weblogic-azure-vm/arm-oraclelinux-wls-cluster/test/scripts/gen-parameters-ag.sh
@@ -50,7 +50,7 @@ cat <<EOF > ${parametersPath}
             "value": 4
         },
         "vmSizeSelect": {
-            "value": "Standard_D2as_v4"
+            "value": "Standard_B2ms"
         },
         "wlsPassword": {
             "value": "GEN-UNIQUE"

--- a/weblogic-azure-vm/arm-oraclelinux-wls-cluster/test/scripts/gen-parameters-coherence.sh
+++ b/weblogic-azure-vm/arm-oraclelinux-wls-cluster/test/scripts/gen-parameters-coherence.sh
@@ -35,7 +35,7 @@ cat <<EOF >${parametersPath}
             "value": "GEN-UNIQUE"
         },
         "vmSizeSelect": {
-            "value": "Standard_D2as_v4"
+            "value": "Standard_B2ms"
         },
         "wlsPassword": {
             "value": "GEN-UNIQUE"

--- a/weblogic-azure-vm/arm-oraclelinux-wls-cluster/test/scripts/gen-parameters-db-aad-ag.sh
+++ b/weblogic-azure-vm/arm-oraclelinux-wls-cluster/test/scripts/gen-parameters-db-aad-ag.sh
@@ -74,7 +74,7 @@ cat <<EOF > ${parametersPath}
             "value": 4
         },
         "vmSizeSelect": {
-            "value": "Standard_D2as_v4"
+            "value": "Standard_B2ms"
         },
         "wlsLDAPGroupBaseDN": {
             "value": "GEN-UNIQUE"

--- a/weblogic-azure-vm/arm-oraclelinux-wls-cluster/test/scripts/gen-parameters-db-aad.sh
+++ b/weblogic-azure-vm/arm-oraclelinux-wls-cluster/test/scripts/gen-parameters-db-aad.sh
@@ -62,7 +62,7 @@ cat <<EOF > ${parametersPath}
             "value": 4
         },
         "vmSizeSelect": {
-            "value": "Standard_D2as_v4"
+            "value": "Standard_B2ms"
         },
         "wlsLDAPGroupBaseDN": {
             "value": "GEN-UNIQUE"

--- a/weblogic-azure-vm/arm-oraclelinux-wls-cluster/test/scripts/gen-parameters-db-ag.sh
+++ b/weblogic-azure-vm/arm-oraclelinux-wls-cluster/test/scripts/gen-parameters-db-ag.sh
@@ -65,7 +65,7 @@ cat <<EOF > ${parametersPath}
             "value": 4
         },
         "vmSizeSelect": {
-            "value": "Standard_D2as_v4"
+            "value": "Standard_B2ms"
         },
         "wlsPassword": {
             "value": "GEN-UNIQUE"

--- a/weblogic-azure-vm/arm-oraclelinux-wls-cluster/test/scripts/gen-parameters-db.sh
+++ b/weblogic-azure-vm/arm-oraclelinux-wls-cluster/test/scripts/gen-parameters-db.sh
@@ -53,7 +53,7 @@ cat <<EOF > ${parametersPath}
             "value": 4
         },
         "vmSizeSelect": {
-            "value": "Standard_D2as_v4"
+            "value": "Standard_B2ms"
         },
         "wlsPassword": {
             "value": "GEN-UNIQUE"

--- a/weblogic-azure-vm/arm-oraclelinux-wls-cluster/test/scripts/gen-parameters-deploy-addnode-coherence.sh
+++ b/weblogic-azure-vm/arm-oraclelinux-wls-cluster/test/scripts/gen-parameters-deploy-addnode-coherence.sh
@@ -38,7 +38,7 @@ cat <<EOF > ${parametersPath}
         "value": "${wlsDomainName}"
       },
       "vmSizeSelectForCoherence": {
-        "value": "Standard_D2as_v4"
+        "value": "Standard_B2ms"
       },
       "wlsPassword": {
         "value": "${wlsPassword}"

--- a/weblogic-azure-vm/arm-oraclelinux-wls-cluster/test/scripts/gen-parameters-deploy-addnode.sh
+++ b/weblogic-azure-vm/arm-oraclelinux-wls-cluster/test/scripts/gen-parameters-deploy-addnode.sh
@@ -41,7 +41,7 @@ cat <<EOF > ${parametersPath}
         "value": "${storageAccountName}"
       },
       "vmSizeSelect": {
-        "value": "Standard_D2as_v4"
+        "value": "Standard_B2ms"
       },
       "wlsDomainName": {
         "value": "${wlsDomainName}"

--- a/weblogic-azure-vm/arm-oraclelinux-wls-cluster/test/scripts/gen-parameters-deploy-coherence.sh
+++ b/weblogic-azure-vm/arm-oraclelinux-wls-cluster/test/scripts/gen-parameters-deploy-coherence.sh
@@ -32,7 +32,7 @@ cat <<EOF > ${parametersPath}
         "value": "${storageAccountName}"
       },
       "vmSizeSelectForCoherence": {
-        "value": "Standard_D2as_v4"
+        "value": "Standard_B2ms"
       },
       "wlsDomainName": {
         "value": "${wlsDomainName}"

--- a/weblogic-azure-vm/arm-oraclelinux-wls-cluster/test/scripts/gen-parameters-elk.sh
+++ b/weblogic-azure-vm/arm-oraclelinux-wls-cluster/test/scripts/gen-parameters-elk.sh
@@ -47,7 +47,7 @@ cat <<EOF >${parametersPath}
             "value": true
         },
         "vmSizeSelect": {
-            "value": "Standard_D2as_v4"
+            "value": "Standard_B2ms"
         },
         "wlsPassword": {
             "value": "GEN-UNIQUE"

--- a/weblogic-azure-vm/arm-oraclelinux-wls-cluster/test/scripts/gen-parameters.sh
+++ b/weblogic-azure-vm/arm-oraclelinux-wls-cluster/test/scripts/gen-parameters.sh
@@ -38,7 +38,7 @@ cat <<EOF > ${parametersPath}
             "value": 4
         },
         "vmSizeSelect": {
-            "value": "Standard_D2as_v4"
+            "value": "Standard_B2ms"
         },
         "wlsPassword": {
             "value": "GEN-UNIQUE"

--- a/weblogic-azure-vm/arm-oraclelinux-wls-cluster/test/scripts/verify-servers-lifecycle.sh
+++ b/weblogic-azure-vm/arm-oraclelinux-wls-cluster/test/scripts/verify-servers-lifecycle.sh
@@ -3,49 +3,65 @@
 # Description
 # This script is to test WebLogic cluster domain managed servers lifecycle. 
 
+read wlsUserName wlspassword adminPublicIP adminPort managedServers
 
-managedServers="#managedServers#"
+CURL_REQD_PARMS="-s -v --user ${wlsUserName}:${wlspassword} -H X-Requested-By:MyClient -H Content-Type:application/json -H Accept:application/json"
+CURL_RETRY_PARMS="--connect-timeout 60 --max-time 180 --retry 10 --retry-delay 30 --retry-max-time 180 --retry-connrefused "
 # Shutdown the server and verify whether it is in SHUTDOWN state
 # Restart the managed server
 for managedServer in $managedServers
 do
-  echo "Shut down managed server : $managedServer"
-  curl --user #wlsUserName#:#wlspassword# -X POST -H 'X-Requested-By: MyClient' -H 'Content-Type: application/json' -H 'Accept: application/json'  -i "http://#adminVMName#:7001/management/weblogic/latest/domainRuntime/serverRuntimes/$managedServer/shutdown" --data '{}'
-  sleep 1m
-  curl --user #wlsUserName#:#wlspassword# -X GET -H 'X-Requested-By: MyClient' -H 'Content-Type: application/json' -H 'Accept: application/json'  -i "http://#adminVMName#:7001/management/weblogic/latest/domainRuntime/serverLifeCycleRuntimes/$managedServer" | grep "\"state\": \"SHUTDOWN\""
-  if [ $? != 0 ]; then
-    echo "$managedServer managed server is not in SHUTDOWN state"
-    exit 1
-  fi   
-  echo "$managedServer managed server is in SHUTDOWN state and starting " 
-  curl --user #wlsUserName#:#wlspassword# -X POST -H 'X-Requested-By: MyClient' -H 'Content-Type: application/json' -H 'Accept: application/json'  -i "http://#adminVMName#:7001/management/weblogic/latest/domainRuntime/serverLifeCycleRuntimes/$managedServer/start" --data '{}'
-  sleep 30s
-done  
+	echo "Shut down managed server : $managedServer"
+	attempt=0
+	while [ $attempt -le 5 ]
+	do
+		echo "Attempt to shutdown $attempt"
+		echo curl ${CURL_REQD_PARMS} -X POST  -i "http://${adminPublicIP}:${adminPort}/management/weblogic/latest/domainRuntime/serverLifeCycleRuntimes/$managedServer/forceShutdown" --data "{}" 
+		curl ${CURL_REQD_PARMS} -X POST  -i "http://${adminPublicIP}:${adminPort}/management/weblogic/latest/domainRuntime/serverLifeCycleRuntimes/$managedServer/forceShutdown" --data "{}" > out
+		echo "Response received for shutdown REST command"
+		cat out
+		echo "Attempt to verify shutdown $attempt"
+		echo curl ${CURL_REQD_PARMS} ${CURL_RETRY_PARMS} -X GET  -i "http://${adminPublicIP}:${adminPort}/management/weblogic/latest/domainRuntime/serverLifeCycleRuntimes/${managedServer}?links=none" 
+		curl ${CURL_REQD_PARMS} ${CURL_RETRY_PARMS} -X GET -i "http://${adminPublicIP}:${adminPort}/management/weblogic/latest/domainRuntime/serverLifeCycleRuntimes/${managedServer}?links=none" > out
+		echo "Recevied response for shutdown verification"
+		cat out
+		cat out | grep "\"state\": \"SHUTDOWN\""
+		if [ $? == 0 ]; then
+			echo "$managedServer managed server is in SHUTDOWN state as expected"
+			break
+		elif [[ $? != 0 ]] && [[ $attempt -ge 5 ]]; then
+			echo "$managedServer managed server is not in SHUTDOWN state after multiple attempts"
+			exit 1
+		fi 
+		attempt=$((attempt+1))
+		sleep 30s
+	done   
 
-echo "Wait for few minutes for managed server to restart"
-sleep 3m
-# Check whether managed server is in RUNNING state
-for managedServer in $managedServers
-do
-  echo "Verifying managed server : $managedServer"
-  isSuccess=false
-  maxAttempt=10
-  attempt=1
-  while [ $attempt -le $maxAttempt ]
-  do
-     curl --user #wlsUserName#:#wlspassword# -X GET -H 'X-Requested-By: MyClient' -H 'Content-Type: application/json' -H 'Accept: application/json'  -i "http://#adminVMName#:7001/management/weblogic/latest/domainRuntime/serverRuntimes/$managedServer" | grep "\"state\": \"RUNNING\""
-     if [ $? == 0 ]; then
-       isSuccess=true
-       break
-     fi
-     attempt=`expr $attempt + 1 `
-     sleep 30s
-  done
-  if [[ $isSuccess == "false" ]]; then
-    echo "$managedServer managed server is not in RUNNING state"
-    exit 1
-  else
-    echo "$managedServer managed server is in RUNNING state"
-  fi
-done
+   	echo "Starting managed server $managedServer"
+   	attempt=0
+  	while [ $attempt -le 5 ]
+  	do
+  		echo "Attempt to starting server $attempt"
+   		echo curl ${CURL_REQD_PARMS}  -X POST -i "http://${adminPublicIP}:${adminPort}/management/weblogic/latest/domainRuntime/serverLifeCycleRuntimes/$managedServer/start" --data "{}"	
+		curl ${CURL_REQD_PARMS} -X POST -i "http://${adminPublicIP}:${adminPort}/management/weblogic/latest/domainRuntime/serverLifeCycleRuntimes/$managedServer/start" --data "{}" > out
+		echo "Response received for start REST command"
+		cat out
+		
+		echo "Attempt to verify start $attempt"
+		echo curl ${CURL_REQD_PARMS} ${CURL_RETRY_PARMS} -X GET -i "http://${adminPublicIP}:${adminPort}/management/weblogic/latest/domainRuntime/serverLifeCycleRuntimes/${managedServer}?links=none"
+		curl ${CURL_REQD_PARMS} ${CURL_RETRY_PARMS} -X GET -i "http://${adminPublicIP}:${adminPort}/management/weblogic/latest/domainRuntime/serverLifeCycleRuntimes/${managedServer}?links=none" > out
+		echo "Recevied response for start verification"
+		cat out
+		cat out | grep "\"state\": \"RUNNING\""
+		if [ $? == 0 ]; then
+			echo "$managedServer managed server is in RUNNING state as expected"
+			break
+		elif [[ $retVal != 0 ]] && [[ $attempt -ge 5 ]]; then
+			echo "$managedServer managed server is not in RUNNING state after multiple attempts"
+			exit 1	 
+		fi 
+    	attempt=$((attempt+1))
+    	sleep 1m
+    done
+done  
 exit 0

--- a/weblogic-azure-vm/arm-oraclelinux-wls-cluster/test/scripts/verify-webapp-deployment.sh
+++ b/weblogic-azure-vm/arm-oraclelinux-wls-cluster/test/scripts/verify-webapp-deployment.sh
@@ -6,9 +6,13 @@
 # This script is to test webapp application deployed on WebLogic cluster domain.
 
 # Verifying webapp deployment
+read appGatewayURL
+
+CURL_RETRY_PARMS="--connect-timeout 60 --max-time 180 --retry 10 --retry-delay 30 --retry-max-time 180 --retry-connrefused"
+
 echo "Verifying WebLogic Cafe is deployed as expected"
-curl --verbose http://#appGatewayURL#/weblogic-cafe/rest/coffees
-response=$(curl --write-out '%{http_code}' --silent --output /dev/null http://#appGatewayURL#/weblogic-cafe/rest/coffees)
+curl --verbose http://${appGatewayURL}/weblogic-cafe/rest/coffees
+response=$(curl ${CURL_RETRY_PARMS}  --write-out '%{http_code}' --silent --output /dev/null http://${appGatewayURL}/weblogic-cafe/rest/coffees)
 echo "$response"
 if [ "$response" -ne 200 ]; then
    echo "WebLogic Cafe is not accessible"

--- a/weblogic-azure-vm/arm-oraclelinux-wls-dynamic-cluster/test/scripts/gen-parameters-aad-ag.sh
+++ b/weblogic-azure-vm/arm-oraclelinux-wls-dynamic-cluster/test/scripts/gen-parameters-aad-ag.sh
@@ -56,7 +56,7 @@ cat <<EOF > ${parametersPath}
             "value": 2
         },
         "vmSizeSelect": {
-            "value": "Standard_D2as_v4"
+            "value": "Standard_B2ms"
         },
         "wlsLDAPGroupBaseDN": {
             "value": "GEN-UNIQUE"

--- a/weblogic-azure-vm/arm-oraclelinux-wls-dynamic-cluster/test/scripts/gen-parameters-aad.sh
+++ b/weblogic-azure-vm/arm-oraclelinux-wls-dynamic-cluster/test/scripts/gen-parameters-aad.sh
@@ -44,7 +44,7 @@ cat <<EOF > ${parametersPath}
             "value": 2
         },
         "vmSizeSelect": {
-            "value": "Standard_D2as_v4"
+            "value": "Standard_B2ms"
         },
         "wlsLDAPGroupBaseDN": {
             "value": "GEN-UNIQUE"

--- a/weblogic-azure-vm/arm-oraclelinux-wls-dynamic-cluster/test/scripts/gen-parameters-coherence.sh
+++ b/weblogic-azure-vm/arm-oraclelinux-wls-dynamic-cluster/test/scripts/gen-parameters-coherence.sh
@@ -29,7 +29,7 @@ cat <<EOF >${parametersPath}
             "value": true
         },
         "vmSizeSelect": {
-            "value": "Standard_D2as_v4"
+            "value": "Standard_B2ms"
         },
         "wlsPassword": {
             "value": "GEN-UNIQUE"

--- a/weblogic-azure-vm/arm-oraclelinux-wls-dynamic-cluster/test/scripts/gen-parameters-db-aad.sh
+++ b/weblogic-azure-vm/arm-oraclelinux-wls-dynamic-cluster/test/scripts/gen-parameters-db-aad.sh
@@ -59,7 +59,7 @@ cat <<EOF > ${parametersPath}
             "value": 2
         },
         "vmSizeSelect": {
-            "value": "Standard_D2as_v4"
+            "value": "Standard_B2ms"
         },
         "wlsLDAPGroupBaseDN": {
             "value": "GEN-UNIQUE"

--- a/weblogic-azure-vm/arm-oraclelinux-wls-dynamic-cluster/test/scripts/gen-parameters-db.sh
+++ b/weblogic-azure-vm/arm-oraclelinux-wls-dynamic-cluster/test/scripts/gen-parameters-db.sh
@@ -50,7 +50,7 @@ cat <<EOF > ${parametersPath}
             "value": 2
         },
         "vmSizeSelect": {
-            "value": "Standard_D2as_v4"
+            "value": "Standard_B2ms"
         },
         "wlsPassword": {
             "value": "GEN-UNIQUE"

--- a/weblogic-azure-vm/arm-oraclelinux-wls-dynamic-cluster/test/scripts/gen-parameters-deploy-addnode-coherence.sh
+++ b/weblogic-azure-vm/arm-oraclelinux-wls-dynamic-cluster/test/scripts/gen-parameters-deploy-addnode-coherence.sh
@@ -33,7 +33,7 @@ cat <<EOF > ${parametersPath}
         "value": "${storageAccountName}"
       },
       "vmSizeSelectForCoherence": {
-            "value": "Standard_D2as_v4"
+            "value": "Standard_B2ms"
       },
       "wlsDomainName": {
         "value": "${wlsDomainName}"

--- a/weblogic-azure-vm/arm-oraclelinux-wls-dynamic-cluster/test/scripts/gen-parameters-deploy-addnode.sh
+++ b/weblogic-azure-vm/arm-oraclelinux-wls-dynamic-cluster/test/scripts/gen-parameters-deploy-addnode.sh
@@ -33,7 +33,7 @@ cat <<EOF > ${parametersPath}
         "value": "${storageAccountName}"
       },
       "vmSizeSelect": {
-            "value": "Standard_D2as_v4"
+            "value": "Standard_B2ms"
       },
       "wlsDomainName": {
         "value": "${wlsDomainName}"

--- a/weblogic-azure-vm/arm-oraclelinux-wls-dynamic-cluster/test/scripts/gen-parameters-deploy-coherence.sh
+++ b/weblogic-azure-vm/arm-oraclelinux-wls-dynamic-cluster/test/scripts/gen-parameters-deploy-coherence.sh
@@ -30,7 +30,7 @@ cat <<EOF > ${parametersPath}
         "value": "${storageAccountName}"
       },
       "vmSizeSelectForCoherence": {
-         "value": "Standard_D2as_v4"
+         "value": "Standard_B2ms"
       },
       "wlsDomainName": {
         "value": "${wlsDomainName}"

--- a/weblogic-azure-vm/arm-oraclelinux-wls-dynamic-cluster/test/scripts/gen-parameters-deploy.sh
+++ b/weblogic-azure-vm/arm-oraclelinux-wls-dynamic-cluster/test/scripts/gen-parameters-deploy.sh
@@ -42,7 +42,7 @@ cat <<EOF >${parametersPath}
       "value": "$adminvmname"
     },
     "vmSizeSelect": {
-      "value": "Standard_D2as_v4"
+      "value": "Standard_B2ms"
     },
     "location": {
       "value": "$location"

--- a/weblogic-azure-vm/arm-oraclelinux-wls-dynamic-cluster/test/scripts/gen-parameters-elk.sh
+++ b/weblogic-azure-vm/arm-oraclelinux-wls-dynamic-cluster/test/scripts/gen-parameters-elk.sh
@@ -41,7 +41,7 @@ cat <<EOF >${parametersPath}
             "value": true
         },
         "vmSizeSelect": {
-            "value": "Standard_D2as_v4"
+            "value": "Standard_B2ms"
         },
         "wlsPassword": {
             "value": "GEN-UNIQUE"

--- a/weblogic-azure-vm/arm-oraclelinux-wls-dynamic-cluster/test/scripts/gen-parameters.sh
+++ b/weblogic-azure-vm/arm-oraclelinux-wls-dynamic-cluster/test/scripts/gen-parameters.sh
@@ -35,7 +35,7 @@ cat <<EOF > ${parametersPath}
             "value": 2
         },
         "vmSizeSelect": {
-            "value": "Standard_D2as_v4"
+            "value": "Standard_B2ms"
         },
         "wlsPassword": {
             "value": "GEN-UNIQUE"

--- a/weblogic-azure-vm/arm-oraclelinux-wls-dynamic-cluster/test/scripts/verify-servers-lifecycle.sh
+++ b/weblogic-azure-vm/arm-oraclelinux-wls-dynamic-cluster/test/scripts/verify-servers-lifecycle.sh
@@ -1,51 +1,67 @@
-#!/bin/bash
 # Copyright (c) 2021, Oracle and/or its affiliates.
 # Licensed under the Universal Permissive License v 1.0 as shown at https://oss.oracle.com/licenses/upl.
-#
+# Description
+# This script is to test WebLogic cluster domain managed servers lifecycle. 
 
-managedServers="#managedServers#"
+read wlsUserName wlspassword adminPublicIP adminPort managedServers
+
+CURL_REQD_PARMS="-s -v --user ${wlsUserName}:${wlspassword} -H X-Requested-By:MyClient -H Content-Type:application/json -H Accept:application/json"
+CURL_RETRY_PARMS="--connect-timeout 60 --max-time 180 --retry 10 --retry-delay 30 --retry-max-time 180 --retry-connrefused "
 # Shutdown the server and verify whether it is in SHUTDOWN state
 # Restart the managed server
 for managedServer in $managedServers
 do
-  echo "Shut down managed server : $managedServer"
-  curl --user #wlsUserName#:#wlspassword# -X POST -H 'X-Requested-By: MyClient' -H 'Content-Type: application/json' -H 'Accept: application/json'  -i "http://#adminVMName#:7001/management/weblogic/latest/domainRuntime/serverRuntimes/$managedServer/shutdown" --data '{}'
-  sleep 1m
-  curl --user #wlsUserName#:#wlspassword# -X GET -H 'X-Requested-By: MyClient' -H 'Content-Type: application/json' -H 'Accept: application/json'  -i "http://#adminVMName#:7001/management/weblogic/latest/domainRuntime/serverLifeCycleRuntimes/$managedServer" | grep "\"state\": \"SHUTDOWN\""
-  if [ $? != 0 ]; then
-    echo "$managedServer managed server is not in SHUTDOWN state"
-    exit 1
-  fi   
-  echo "$managedServer managed server is in SHUTDOWN state and starting " 
-  curl --user #wlsUserName#:#wlspassword# -X POST -H 'X-Requested-By: MyClient' -H 'Content-Type: application/json' -H 'Accept: application/json'  -i "http://#adminVMName#:7001/management/weblogic/latest/domainRuntime/serverLifeCycleRuntimes/$managedServer/start" --data '{}'
-  sleep 30s
+	echo "Shut down managed server : $managedServer"
+	attempt=0
+	while [ $attempt -le 5 ]
+	do
+		echo "Attempt to shutdown $attempt"
+		echo curl ${CURL_REQD_PARMS} -X POST  -i "http://${adminPublicIP}:${adminPort}/management/weblogic/latest/domainRuntime/serverLifeCycleRuntimes/$managedServer/forceShutdown" --data "{}" 
+		curl ${CURL_REQD_PARMS} -X POST  -i "http://${adminPublicIP}:${adminPort}/management/weblogic/latest/domainRuntime/serverLifeCycleRuntimes/$managedServer/forceShutdown" --data "{}" > out
+		echo "Response received for shutdown REST command"
+		cat out
+		echo "Attempt to verify shutdown $attempt"
+		echo curl ${CURL_REQD_PARMS} ${CURL_RETRY_PARMS} -X GET  -i "http://${adminPublicIP}:${adminPort}/management/weblogic/latest/domainRuntime/serverLifeCycleRuntimes/${managedServer}?links=none" 
+		curl ${CURL_REQD_PARMS} ${CURL_RETRY_PARMS} -X GET -i "http://${adminPublicIP}:${adminPort}/management/weblogic/latest/domainRuntime/serverLifeCycleRuntimes/${managedServer}?links=none" > out
+		echo "Recevied response for shutdown verification"
+		cat out
+		cat out | grep "\"state\": \"SHUTDOWN\""
+		if [ $? == 0 ]; then
+			echo "$managedServer managed server is in SHUTDOWN state as expected"
+			break
+		elif [[ $? != 0 ]] && [[ $attempt -ge 5 ]]; then
+			echo "$managedServer managed server is not in SHUTDOWN state after multiple attempts"
+			exit 1
+		fi 
+		attempt=$((attempt+1))
+		sleep 30s
+	done   
+
+   	echo "Starting managed server $managedServer"
+   	attempt=0
+  	while [ $attempt -le 5 ]
+  	do
+  		echo "Attempt to starting server $attempt"
+   		echo curl ${CURL_REQD_PARMS}  -X POST -i "http://${adminPublicIP}:${adminPort}/management/weblogic/latest/domainRuntime/serverLifeCycleRuntimes/$managedServer/start" --data "{}"	
+		curl ${CURL_REQD_PARMS} -X POST -i "http://${adminPublicIP}:${adminPort}/management/weblogic/latest/domainRuntime/serverLifeCycleRuntimes/$managedServer/start" --data "{}" > out
+		echo "Response received for start REST command"
+		cat out
+		
+		echo "Attempt to verify start $attempt"
+		echo curl ${CURL_REQD_PARMS} ${CURL_RETRY_PARMS} -X GET -i "http://${adminPublicIP}:${adminPort}/management/weblogic/latest/domainRuntime/serverLifeCycleRuntimes/${managedServer}?links=none"
+		curl ${CURL_REQD_PARMS} ${CURL_RETRY_PARMS} -X GET -i "http://${adminPublicIP}:${adminPort}/management/weblogic/latest/domainRuntime/serverLifeCycleRuntimes/${managedServer}?links=none" > out
+		echo "Recevied response for start verification"
+		cat out
+		cat out | grep "\"state\": \"RUNNING\""
+		if [ $? == 0 ]; then
+			echo "$managedServer managed server is in RUNNING state as expected"
+			break
+		elif [[ $retVal != 0 ]] && [[ $attempt -ge 5 ]]; then
+			echo "$managedServer managed server is not in RUNNING state after multiple attempts"
+			exit 1	 
+		fi 
+    	attempt=$((attempt+1))
+    	sleep 1m
+    done
 done  
-
-echo "Wait for few minutes for managed server to restart"
-sleep 3m
-# Check whether managed server is in RUNNING state
-for managedServer in $managedServers
-do
-  echo "Verifying managed server : $managedServer"
-  isSuccess=false
-  maxAttempt=10
-  attempt=1
-  while [ $attempt -le $maxAttempt ]
-  do
-     curl --user #wlsUserName#:#wlspassword# -X GET -H 'X-Requested-By: MyClient' -H 'Content-Type: application/json' -H 'Accept: application/json'  -i "http://#adminVMName#:7001/management/weblogic/latest/domainRuntime/serverRuntimes/$managedServer" | grep "\"state\": \"RUNNING\""
-     if [ $? == 0 ]; then
-       isSuccess=true
-       break
-     fi
-     attempt=`expr $attempt + 1 `
-     sleep 30s
-  done
-  if [[ $isSuccess == "false" ]]; then
-    echo "$managedServer managed server is not in RUNNING state"
-    exit 1
-  else
-    echo "$managedServer managed server is in RUNNING state"
-  fi
-done
 exit 0
-


### PR DESCRIPTION
1. Updated CICD workflow files for cluster and dynamic cluster offers.
    -  Updated invoking verify-servers-lifecycle and deployment scripts with STDIN arguments
    -  verify-servers-lifecycle and deployment scripts are running remotely rather inside adminvm
    -  Removed "Restart remote SSH agent" wherever it is not required

2. Updated verify-servers-lifecycle and deployment scripts 
   -  To handle the REST response errors
   -  Included more verification and status REST response checking
   - Accepting STDIN arguments
