### PR TITLE
update az cli command to create the Active Directory Service Principal and encode with base64.

### DIFF
--- a/weblogic-azure-aks/src/main/arm/createUiDefinition.json
+++ b/weblogic-azure-aks/src/main/arm/createUiDefinition.json
@@ -1512,7 +1512,7 @@
                                 "visible": "[steps('section_appGateway').appgwIngress.enableAppGateway]",
                                 "options": {
                                     "icon": "Info",
-                                    "text": "You must input an Active Directory Service Principal that is encoded with base64 to create the Application Gateway Ingress Controller. See this <a href=https://aka.ms/wls-aks-agic-sp-doc target='_blank'>document</a> for more information.</br>You can generate one with command <b>az ad sp create-for-rbac --role Contributor --sdk-auth | base64 -w0</b>"
+                                    "text": "You must input an Active Directory Service Principal that is encoded with base64 to create the Application Gateway Ingress Controller. See this <a href=https://aka.ms/wls-aks-agic-sp-doc target='_blank'>document</a> for more information.</br>You can generate one with command <b>az ad sp create-for-rbac --role Contributor --sdk-auth | base64 -w0</b>. On macOS omit the <b>-w0</b>."
                                 }
                             },
                             {
@@ -1522,7 +1522,7 @@
                                     "password": "Service Principal",
                                     "confirmPassword": "Confirm password"
                                 },
-                                "toolTip": "Base64 encoded JSON blob of the service principal. You can generate one with command 'az ad sp create-for-rbac --role Contributor --sdk-auth | base64 -w0'",
+                                "toolTip": "Base64 encoded JSON blob of the service principal. You can generate one with command 'az ad sp create-for-rbac --role Contributor --sdk-auth | base64 -w0' On macOS omit the -w0.",
                                 "constraints": {
                                     "required": true
                                 },

--- a/weblogic-azure-aks/src/main/arm/createUiDefinition.json
+++ b/weblogic-azure-aks/src/main/arm/createUiDefinition.json
@@ -1512,7 +1512,7 @@
                                 "visible": "[steps('section_appGateway').appgwIngress.enableAppGateway]",
                                 "options": {
                                     "icon": "Info",
-                                    "text": "You must input an Active Directory Service Principal and encode with base64 to create the Application Gateway Ingress Controller. See this <a href=https://aka.ms/wls-aks-agic-sp-doc target='_blank'>document</a> for more information.</br>You can generate one with command<b>az ad sp create-for-rbac --role Contributor --sdk-auth | base64 -w0</b>"
+                                    "text": "You must input an Active Directory Service Principal that is encoded with base64 to create the Application Gateway Ingress Controller. See this <a href=https://aka.ms/wls-aks-agic-sp-doc target='_blank'>document</a> for more information.</br>You can generate one with command <b>az ad sp create-for-rbac --role Contributor --sdk-auth | base64 -w0</b>"
                                 }
                             },
                             {

--- a/weblogic-azure-aks/src/main/arm/createUiDefinition.json
+++ b/weblogic-azure-aks/src/main/arm/createUiDefinition.json
@@ -1507,13 +1507,22 @@
                                 "visible": "[and(steps('section_sslConfiguration').enableCustomSSL, equals(steps('section_appGateway').appgwIngress.certificateOption, 'haveKeyVault'))]"
                             },
                             {
+                                "name": "agicSpInfo",
+                                "type": "Microsoft.Common.InfoBox",
+                                "visible": "[steps('section_appGateway').appgwIngress.enableAppGateway]",
+                                "options": {
+                                    "icon": "Info",
+                                    "text": "You must input an Active Directory Service Principal and encode with base64 to create the Application Gateway Ingress Controller. See this <a href=https://aka.ms/wls-aks-agic-sp-doc target='_blank'>document</a> for more information.</br>You can generate one with command<b>az ad sp create-for-rbac --role Contributor --sdk-auth | base64 -w0</b>"
+                                }
+                            },
+                            {
                                 "name": "servicePrincipal",
                                 "type": "Microsoft.Common.PasswordBox",
                                 "label": {
                                     "password": "Service Principal",
                                     "confirmPassword": "Confirm password"
                                 },
-                                "toolTip": "Base64 encoded JSON blob of the service principal. You can generate one with command 'az ad sp create-for-rbac --sdk-auth | base64 -w0'",
+                                "toolTip": "Base64 encoded JSON blob of the service principal. You can generate one with command 'az ad sp create-for-rbac --role Contributor --sdk-auth | base64 -w0'",
                                 "constraints": {
                                     "required": true
                                 },


### PR DESCRIPTION
Update az cli command to create service principal:

`az ad sp create-for-rbac --role Contributor --sdk-auth | base64 -w0`

See [Using a Service Principal to install AGIC](https://docs.microsoft.com/en-us/azure/application-gateway/ingress-controller-install-existing#using-a-service-principal)


Signed-off-by: galiacheng <haixia.cheng@microsoft.com>

 Changes to be committed:
	modified:   weblogic-azure-aks/src/main/arm/createUiDefinition.json
	modified:   weblogic-azure-aks/src/main/arm/scripts/inline-scripts/validateParameters.sh