### PR TITLE
Enable application gateway firewall "Prevention" mode in VM offer

### DIFF
--- a/weblogic-azure-vm/arm-oraclelinux-wls-cluster/arm-oraclelinux-wls-cluster/src/main/arm/nestedtemplates/appGatewayNestedTemplate.json
+++ b/weblogic-azure-vm/arm-oraclelinux-wls-cluster/arm-oraclelinux-wls-cluster/src/main/arm/nestedtemplates/appGatewayNestedTemplate.json
@@ -371,6 +371,13 @@
 						"type": "Microsoft.Network/applicationGateways/probes"
 					}
 				],
+				"webApplicationFirewallConfiguration": {
+					"enabled": true,
+					"firewallMode": "Prevention",
+					"ruleSetType": "OWASP",
+					"ruleSetVersion": "3.0",
+					"disabledRuleGroups": []
+				},
 				"enableHttp2": false,
 				"autoscaleConfiguration": {
 					"minCapacity": 2,


### PR DESCRIPTION
Enable application gateway firewall "Prevention" mode in VM offer to protect the WLS cluster.

Signed-off-by: galiacheng <haixia.cheng@microsoft.com>

 On branch vm-appgateway-waf-prevention
 Changes to be committed:
	modified:   weblogic-azure-vm/arm-oraclelinux-wls-cluster/arm-oraclelinux-wls-cluster/src/main/arm/nestedtemplates/appGatewayNestedTemplate.json


Test: https://github.com/galiacheng/weblogic-azure/actions/runs/1816158562