### PR TITLE
Customize AKS version

### DIFF
--- a/weblogic-azure-aks/pom.xml
+++ b/weblogic-azure-aks/pom.xml
@@ -17,7 +17,7 @@
 
   <groupId>com.oracle.weblogic.azure</groupId>
   <artifactId>wls-on-aks-azure-marketplace</artifactId>
-  <version>1.0.35</version>
+  <version>1.0.36</version>
 
   <parent>
     <groupId>com.microsoft.azure.iaas</groupId>

--- a/weblogic-azure-aks/src/main/arm/createUiDefinition.json
+++ b/weblogic-azure-aks/src/main/arm/createUiDefinition.json
@@ -337,7 +337,7 @@
                                 "visible": "[bool(steps('section_aks').clusterInfo.createAKSCluster)]",
                                 "options": {
                                     "icon": "Info",
-                                    "text": "This application is tested with specified version of Kubernetes; click 'Learn more' to the find the version information. You are also able to input a desired version, if you run into problem with that version, please report an issue.",
+                                    "text": "This offer is tested with specified version of Kubernetes; click 'Learn more' to the find the version information. You are also able to input a desired version, if you run into problem with that version, please report an issue.",
                                     "link": {
                                         "label": "Learn more",
                                         "uri": "https://aka.ms/wls-aks-well-tested-version"

--- a/weblogic-azure-aks/src/main/arm/createUiDefinition.json
+++ b/weblogic-azure-aks/src/main/arm/createUiDefinition.json
@@ -332,12 +332,12 @@
                                 "visible": "[not(bool(steps('section_aks').clusterInfo.createAKSCluster))]"
                             },
                             {
-                                "name": "aksWellTestedVersionTextBlock",
+                                "name": "aksSupportedVersionTextBlock",
                                 "type": "Microsoft.Common.TextBlock",
                                 "visible": "[bool(steps('section_aks').clusterInfo.createAKSCluster)]",
                                 "options": {
                                     "icon": "Info",
-                                    "text": "This offer is tested with specified version of Kubernetes; click 'Learn more' to the find the version information. You are also able to input a desired version, if you run into problem with that version, please report an issue.",
+                                    "text": "AKS supports a range of Kubernetes versions.  This offer is tested with with a specific Kubernetes version known to work with WebLogic server on AKS; click 'Learn more' to the find the version information.",
                                     "link": {
                                         "label": "Learn more",
                                         "uri": "https://aka.ms/wls-aks-well-tested-version"
@@ -345,11 +345,11 @@
                                 }
                             },
                             {
-                                "name": "useAksWellTestedVersion",
+                                "name": "useLatestSupportedAksVersion",
                                 "type": "Microsoft.Common.OptionsGroup",
-                                "label": "Use well-tested Kubernetes version",
+                                "label": "Use latest supported AKS Kubernetes version",
                                 "defaultValue": "Yes",
-                                "toolTip": "If yes, use a well-tested Kubernetes version; if no, input your desired version.",
+                                "toolTip": "If yes, use the latest supported AKS Kubernetes version; if no, input a version using the known supported versions listed in the document linked above.",
                                 "constraints": {
                                     "allowedValues": [
                                         {
@@ -375,7 +375,7 @@
                                     "regex": "^(0|[1-9]\\d*)\\.(0|[1-9]\\d*)\\.(0|[1-9]\\d*)(-[a-zA-Z\\d][-a-zA-Z.\\d]*)?(\\+[a-zA-Z\\d][-a-zA-Z.\\d]*)?$",
                                     "validationMessage": "Use semantic versioning (Major.Minor.Patch)."
                                 },
-                                "visible": "[and(bool(steps('section_aks').clusterInfo.createAKSCluster),not(bool(steps('section_aks').clusterInfo.useAksWellTestedVersion)))]"
+                                "visible": "[and(bool(steps('section_aks').clusterInfo.createAKSCluster),not(bool(steps('section_aks').clusterInfo.useLatestSupportedAksVersion)))]"
                             },
                             {
                                 "name": "aksNodeCount",
@@ -2161,7 +2161,7 @@
             "sslUploadedCustomTrustKeyStoreType": "[steps('section_sslConfiguration').uploadedCustomSSLSettings.uploadedCustomTrustKeyStoreType]",
             "sslUploadedPrivateKeyAlias": "[steps('section_sslConfiguration').uploadedCustomSSLSettings.uploadedPrivateKeyAlias]",
             "sslUploadedPrivateKeyPassPhrase": "[steps('section_sslConfiguration').uploadedCustomSSLSettings.uploadedPrivateKeyPassPhrase]",
-            "useAksWellTestedVersion": "[bool(steps('section_aks').clusterInfo.useAksWellTestedVersion)]",
+            "useLatestSupportedAksVersion": "[bool(steps('section_aks').clusterInfo.useLatestSupportedAksVersion)]",
             "useInternalLB": "[bool(steps('section_appGateway').lbSVCInfo.enableInternalLB)]",
             "useOracleImage": "[bool(steps('section_aks').imageInfo.useOracleImage)]",
             "userProvidedAcr": "[last(split(steps('section_aks').imageInfo.userProvidedAcrSelector.id, '/'))]",

--- a/weblogic-azure-aks/src/main/arm/createUiDefinition.json
+++ b/weblogic-azure-aks/src/main/arm/createUiDefinition.json
@@ -429,7 +429,7 @@
                                 "type": "Microsoft.Common.OptionsGroup",
                                 "label": "Use a pre-existing, WebLogic Server Docker image from Oracle Container Registry?",
                                 "defaultValue": "Yes",
-                                "toolTip": "Select 'Yes' to a use pre-existing, WebLogic Server Docker image from the public Oracle Container Registry. Select 'No' to use a pre-existing Docker image, assumed to be a compatible WebLogic server image, from the specified ACR instance. This allows the use of custom images, such as with a specific set of patches (PSUs).",
+                                "toolTip": "Select 'Yes' to a use pre-existing, WebLogic Server Docker image from the public Oracle Container Registry. Select 'No' to use a pre-existing Docker image, assumed to be a compatible WebLogic Server image, from the specified ACR instance. This allows the use of custom images, such as with a specific set of patches (PSUs).",
                                 "constraints": {
                                     "allowedValues": [
                                         {

--- a/weblogic-azure-aks/src/main/arm/createUiDefinition.json
+++ b/weblogic-azure-aks/src/main/arm/createUiDefinition.json
@@ -337,7 +337,7 @@
                                 "visible": "[bool(steps('section_aks').clusterInfo.createAKSCluster)]",
                                 "options": {
                                     "icon": "Info",
-                                    "text": "AKS supports a range of Kubernetes versions.  This offer is tested with with a specific Kubernetes version known to work with WebLogic server on AKS; click 'Learn more' to the find the version information.",
+                                    "text": "AKS supports a range of Kubernetes versions.  This offer is tested with a specific Kubernetes version known to work with WebLogic Server on AKS; click 'Learn more' to the find the version information.",
                                     "link": {
                                         "label": "Learn more",
                                         "uri": "https://aka.ms/wls-aks-well-tested-version"

--- a/weblogic-azure-aks/src/main/arm/createUiDefinition.json
+++ b/weblogic-azure-aks/src/main/arm/createUiDefinition.json
@@ -281,6 +281,18 @@
                 "bladeTitle": "Configure AKS cluster",
                 "elements": [
                     {
+                        "name": "domainHomeSourceTypeExplainer",
+                        "type": "Microsoft.Common.TextBlock",
+                        "visible": true,
+                        "options": {
+                            "text": "This offer always deploys WebLogic using the 'Model in image' domain home source type, even when the persistent volume checkbox is checked.  For more information on domain home source types, follow the link below",
+                            "link": {
+                                "label": "Learn more",
+                                "uri": "https://aka.ms/wls-aks-docs-domain-home-source-type"
+                            }
+                        }
+                    },
+                    {
                         "name": "clusterInfo",
                         "type": "Microsoft.Common.Section",
                         "label": "Azure Kubernetes Service",
@@ -318,6 +330,52 @@
                                     }
                                 },
                                 "visible": "[not(bool(steps('section_aks').clusterInfo.createAKSCluster))]"
+                            },
+                            {
+                                "name": "aksWellTestedVersionTextBlock",
+                                "type": "Microsoft.Common.TextBlock",
+                                "visible": "[bool(steps('section_aks').clusterInfo.createAKSCluster)]",
+                                "options": {
+                                    "icon": "Info",
+                                    "text": "This application is tested with specified version of Kubernetes; click 'Learn more' to the find the version information. You are also able to input a desired version, if you run into problem with that version, please report an issue.",
+                                    "link": {
+                                        "label": "Learn more",
+                                        "uri": "https://aka.ms/wls-aks-well-tested-version"
+                                    }
+                                }
+                            },
+                            {
+                                "name": "useAksWellTestedVersion",
+                                "type": "Microsoft.Common.OptionsGroup",
+                                "label": "Use well-tested Kubernetes version",
+                                "defaultValue": "Yes",
+                                "toolTip": "If yes, use a well-tested Kubernetes version; if no, input your desired version.",
+                                "constraints": {
+                                    "allowedValues": [
+                                        {
+                                            "label": "Yes",
+                                            "value": "true"
+                                        },
+                                        {
+                                            "label": "No",
+                                            "value": "false"
+                                        }
+                                    ],
+                                    "required": true
+                                },
+                                "visible": "[bool(steps('section_aks').clusterInfo.createAKSCluster)]"
+                            },
+                            {
+                                "name": "aksVersion",
+                                "type": "Microsoft.Common.TextBox",
+                                "label": "Input Kubernetes version",
+                                "toolTip": "Use semantic versioning (Major.Minor.Patch)",
+                                "constraints": {
+                                    "required": true,
+                                    "regex": "^(0|[1-9]\\d*)\\.(0|[1-9]\\d*)\\.(0|[1-9]\\d*)(-[a-zA-Z\\d][-a-zA-Z.\\d]*)?(\\+[a-zA-Z\\d][-a-zA-Z.\\d]*)?$",
+                                    "validationMessage": "Use semantic versioning (Major.Minor.Patch)."
+                                },
+                                "visible": "[and(bool(steps('section_aks').clusterInfo.createAKSCluster),not(bool(steps('section_aks').clusterInfo.useAksWellTestedVersion)))]"
                             },
                             {
                                 "name": "aksNodeCount",
@@ -374,11 +432,15 @@
                             },
                             {
                                 "name": "enableAzureFileShareTextBlock",
-                                "type": "Microsoft.Common.InfoBox",
+                                "type": "Microsoft.Common.TextBlock",
                                 "visible": "[bool(steps('section_aks').clusterInfo.createAKSCluster)]",
                                 "options": {
                                     "icon": "Info",
-                                    "text": "If checked,  an Azure Storage Account and an Azure Files share will be provisioned; static persistent volume with the Azure Files share will be mounted the nodes of the AKS cluster. <br>You can find more information from <a href='https://docs.microsoft.com/azure/aks/azure-files-volume' target='_blank'>persistent volume with Azure Files share on AKS</a> and <a href='https://aka.ms/wls-aks-persistent-storage' target='_blank'>Oracle WebLogic persistent storage</a>."
+                                    "text": "If checked, configure the necessary settings to mount a persistent volume to the nodes of the AKS cluster. This can be useful for storing log files outside of the AKS cluster, among other possible uses. An Azure Storage Account and an Azure Files share will be provisioned; static persistent volume with the Azure Files share will be mounted to the nodes of the AKS cluster.",
+                                    "link": {
+                                        "label": "Learn more",
+                                        "uri": "https://aka.ms/wls-aks-persistent-storage"
+                                    }
                                 }
                             },
                             {
@@ -2031,6 +2093,7 @@
             "aksAgentPoolVMSize": "[steps('section_aks').clusterInfo.nodeVMSizeSelector]",
             "aksClusterName": "[last(split(steps('section_aks').clusterInfo.aksClusterSelector.id, '/'))]",
             "aksClusterRGName": "[last(take(split(steps('section_aks').clusterInfo.aksClusterSelector.id, '/'), 5))]",
+            "aksVersion": "[steps('section_aks').clusterInfo.aksVersion]",
             "appGatewayCertificateOption": "[steps('section_appGateway').appgwIngress.certificateOption]",
             "appGatewaySSLBackendRootCertData": "[steps('section_appGateway').appgwIngress.keyVaultBackendSSLCertData]",
             "appGatewaySSLCertData": "[steps('section_appGateway').appgwIngress.keyVaultSSLCertData]",
@@ -2098,6 +2161,7 @@
             "sslUploadedCustomTrustKeyStoreType": "[steps('section_sslConfiguration').uploadedCustomSSLSettings.uploadedCustomTrustKeyStoreType]",
             "sslUploadedPrivateKeyAlias": "[steps('section_sslConfiguration').uploadedCustomSSLSettings.uploadedPrivateKeyAlias]",
             "sslUploadedPrivateKeyPassPhrase": "[steps('section_sslConfiguration').uploadedCustomSSLSettings.uploadedPrivateKeyPassPhrase]",
+            "useAksWellTestedVersion": "[bool(steps('section_aks').clusterInfo.useAksWellTestedVersion)]",
             "useInternalLB": "[bool(steps('section_appGateway').lbSVCInfo.enableInternalLB)]",
             "useOracleImage": "[bool(steps('section_aks').imageInfo.useOracleImage)]",
             "userProvidedAcr": "[last(split(steps('section_aks').imageInfo.userProvidedAcrSelector.id, '/'))]",

--- a/weblogic-azure-aks/src/main/arm/createUiDefinition.json
+++ b/weblogic-azure-aks/src/main/arm/createUiDefinition.json
@@ -345,39 +345,6 @@
                                 }
                             },
                             {
-                                "name": "useLatestSupportedAksVersion",
-                                "type": "Microsoft.Common.OptionsGroup",
-                                "label": "Use latest supported AKS Kubernetes version",
-                                "defaultValue": "Yes",
-                                "toolTip": "If yes, use the latest supported AKS Kubernetes version; if no, input a version using the known supported versions listed in the document linked above.",
-                                "constraints": {
-                                    "allowedValues": [
-                                        {
-                                            "label": "Yes",
-                                            "value": "true"
-                                        },
-                                        {
-                                            "label": "No",
-                                            "value": "false"
-                                        }
-                                    ],
-                                    "required": true
-                                },
-                                "visible": "[bool(steps('section_aks').clusterInfo.createAKSCluster)]"
-                            },
-                            {
-                                "name": "aksVersion",
-                                "type": "Microsoft.Common.TextBox",
-                                "label": "Input Kubernetes version",
-                                "toolTip": "Use semantic versioning (Major.Minor.Patch)",
-                                "constraints": {
-                                    "required": true,
-                                    "regex": "^(0|[1-9]\\d*)\\.(0|[1-9]\\d*)\\.(0|[1-9]\\d*)(-[a-zA-Z\\d][-a-zA-Z.\\d]*)?(\\+[a-zA-Z\\d][-a-zA-Z.\\d]*)?$",
-                                    "validationMessage": "Use semantic versioning (Major.Minor.Patch)."
-                                },
-                                "visible": "[and(bool(steps('section_aks').clusterInfo.createAKSCluster),not(bool(steps('section_aks').clusterInfo.useLatestSupportedAksVersion)))]"
-                            },
-                            {
                                 "name": "aksNodeCount",
                                 "type": "Microsoft.Common.Slider",
                                 "min": 1,
@@ -2093,7 +2060,6 @@
             "aksAgentPoolVMSize": "[steps('section_aks').clusterInfo.nodeVMSizeSelector]",
             "aksClusterName": "[last(split(steps('section_aks').clusterInfo.aksClusterSelector.id, '/'))]",
             "aksClusterRGName": "[last(take(split(steps('section_aks').clusterInfo.aksClusterSelector.id, '/'), 5))]",
-            "aksVersion": "[steps('section_aks').clusterInfo.aksVersion]",
             "appGatewayCertificateOption": "[steps('section_appGateway').appgwIngress.certificateOption]",
             "appGatewaySSLBackendRootCertData": "[steps('section_appGateway').appgwIngress.keyVaultBackendSSLCertData]",
             "appGatewaySSLCertData": "[steps('section_appGateway').appgwIngress.keyVaultSSLCertData]",
@@ -2161,7 +2127,6 @@
             "sslUploadedCustomTrustKeyStoreType": "[steps('section_sslConfiguration').uploadedCustomSSLSettings.uploadedCustomTrustKeyStoreType]",
             "sslUploadedPrivateKeyAlias": "[steps('section_sslConfiguration').uploadedCustomSSLSettings.uploadedPrivateKeyAlias]",
             "sslUploadedPrivateKeyPassPhrase": "[steps('section_sslConfiguration').uploadedCustomSSLSettings.uploadedPrivateKeyPassPhrase]",
-            "useLatestSupportedAksVersion": "[bool(steps('section_aks').clusterInfo.useLatestSupportedAksVersion)]",
             "useInternalLB": "[bool(steps('section_appGateway').lbSVCInfo.enableInternalLB)]",
             "useOracleImage": "[bool(steps('section_aks').imageInfo.useOracleImage)]",
             "userProvidedAcr": "[last(split(steps('section_aks').imageInfo.userProvidedAcrSelector.id, '/'))]",

--- a/weblogic-azure-aks/src/main/arm/scripts/common.sh
+++ b/weblogic-azure-aks/src/main/arm/scripts/common.sh
@@ -24,6 +24,8 @@ export ocrLoginServer="container-registry.oracle.com"
 export ocrGaImagePath="middleware/weblogic"
 export ocrCpuImagePath="middleware/weblogic_cpu"
 export gitUrl4CpuImages="https://raw.githubusercontent.com/oracle/weblogic-azure/main/weblogic-azure-aks/src/main/resources/weblogic_cpu_images.json"
+export gitUrl4AksWellTestedVersionJsonFile="https://raw.githubusercontent.com/oracle/weblogic-azure/main/weblogic-azure-aks/src/main/resources/aks_well_tested_version.json"
+
 export optUninstallMaxTry=5 # Max attempts to wait for the operator uninstalled
 export optUninstallInterval=10
 

--- a/weblogic-azure-aks/src/main/arm/scripts/common.sh
+++ b/weblogic-azure-aks/src/main/arm/scripts/common.sh
@@ -15,6 +15,7 @@ export constClusterName='cluster-1'
 export constClusterT3AddressEnvName="T3_TUNNELING_CLUSTER_ADDRESS"
 export constDefaultJavaOptions="-Dlog4j2.formatMsgNoLookups=true -Dweblogic.StdoutDebugEnabled=false" # the java options will be applied to the cluster
 export constDefaultJVMArgs="-Djava.security.egd=file:/dev/./urandom -Xms256m -Xmx512m -XX:MinRAMPercentage=25.0 -XX:MaxRAMPercentage=50.0 " # the JVM options will be applied to the cluster
+export constDefaultAKSVersion="default"
 export constFalse="false"
 export constTrue="true"
 export constIntrospectorJobActiveDeadlineSeconds=300  # for Guaranteed Qos

--- a/weblogic-azure-aks/src/main/arm/scripts/inline-scripts/validateParameters.sh
+++ b/weblogic-azure-aks/src/main/arm/scripts/inline-scripts/validateParameters.sh
@@ -614,7 +614,7 @@ appGatewayCertificateOption=${10}
 enableAppGWIngress=${11}
 checkDNSZone=${12}
 
-gitUrl4AksWellTestedVersionJsonFile="https://raw.githubusercontent.com/galiacheng/weblogic-azure/aks-well-tested-version/weblogic-azure-aks/src/main/resources/aks_well_tested_version.json"
+gitUrl4AksWellTestedVersionJsonFile="https://raw.githubusercontent.com/oracle/weblogic-azure/main/weblogic-azure-aks/src/main/resources/aks_well_tested_version.json"
 sslCertificateKeyVaultOption="keyVaultStoredConfig"
 userManagedIdentityType="Microsoft.ManagedIdentity/userAssignedIdentities"
 

--- a/weblogic-azure-aks/src/main/arm/scripts/inline-scripts/validateParameters.sh
+++ b/weblogic-azure-aks/src/main/arm/scripts/inline-scripts/validateParameters.sh
@@ -574,7 +574,7 @@ function validate_aks_version() {
     local ret=$(az aks get-versions --location ${location} \
       | jq ".orchestrators[] | select(.orchestratorVersion == \"${aksWellTestedVersion}\") | .orchestratorVersion" \
       | tr -d "\"")
-    if [[ "${ret}" ==  "${aksWellTestedVersion}" ]]; then
+    if [[ "${aksWellTestedVersion}" !=  "" ]] && [[ "${ret}" ==  "${aksWellTestedVersion}" ]]; then
       outputAksVersion=${aksWellTestedVersion}
     else
       # if the well-tested version is invalid, use default version.

--- a/weblogic-azure-aks/src/main/arm/scripts/inline-scripts/validateParameters.sh
+++ b/weblogic-azure-aks/src/main/arm/scripts/inline-scripts/validateParameters.sh
@@ -614,7 +614,6 @@ appGatewayCertificateOption=${10}
 enableAppGWIngress=${11}
 checkDNSZone=${12}
 
-gitUrl4AksWellTestedVersionJsonFile="https://raw.githubusercontent.com/oracle/weblogic-azure/main/weblogic-azure-aks/src/main/resources/aks_well_tested_version.json"
 sslCertificateKeyVaultOption="keyVaultStoredConfig"
 userManagedIdentityType="Microsoft.ManagedIdentity/userAssignedIdentities"
 

--- a/weblogic-azure-aks/src/main/bicep/mainTemplate.bicep
+++ b/weblogic-azure-aks/src/main/bicep/mainTemplate.bicep
@@ -46,7 +46,7 @@ param aksClusterRGName string = 'aks-contoso-rg'
 @description('Name of an existing AKS cluster.')
 param aksClusterName string = 'aks-contoso'
 @description('The AKS version.')
-param aksVersion string = '1.21.9'
+param aksVersion string = 'default'
 @allowed([
   'haveCert'
   'haveKeyVault'

--- a/weblogic-azure-aks/src/main/bicep/mainTemplate.bicep
+++ b/weblogic-azure-aks/src/main/bicep/mainTemplate.bicep
@@ -46,7 +46,7 @@ param aksClusterRGName string = 'aks-contoso-rg'
 @description('Name of an existing AKS cluster.')
 param aksClusterName string = 'aks-contoso'
 @description('The AKS version.')
-param aksVersion string = 'default'
+param aksVersion string = '1.21.9'
 @allowed([
   'haveCert'
   'haveKeyVault'

--- a/weblogic-azure-aks/src/main/bicep/mainTemplate.bicep
+++ b/weblogic-azure-aks/src/main/bicep/mainTemplate.bicep
@@ -229,8 +229,8 @@ param sslUploadedPrivateKeyPassPhrase string = newGuid()
 param t3ChannelAdminPort int = 7005
 @description('Public port of the custom T3 channel in WebLoigc cluster')
 param t3ChannelClusterPort int = 8011
-@description('True to use well-tesed Kubernetes version.')
-param useAksWellTestedVersion bool = true
+@description('True to use latest supported Kubernetes version.')
+param useLatestSupportedAksVersion bool = true
 @description('True to set up internal load balancer service.')
 param useInternalLB bool = false
 @description('ture to upload Java EE applications and deploy the applications to WebLogic domain.')
@@ -376,7 +376,7 @@ module validateInputs 'modules/_deployment-scripts/_ds-validate-parameters.bicep
     sslUploadedCustomTrustKeyStoreType: sslUploadedCustomTrustKeyStoreType
     sslUploadedPrivateKeyAlias: sslUploadedPrivateKeyAlias
     sslUploadedPrivateKeyPassPhrase: sslUploadedPrivateKeyPassPhrase
-    useAksWellTestedVersion: useAksWellTestedVersion
+    useAksWellTestedVersion: useLatestSupportedAksVersion
     userProvidedAcr: userProvidedAcr // used in user provided images
     userProvidedImagePath: userProvidedImagePath
     useOracleImage: useOracleImage

--- a/weblogic-azure-aks/src/main/bicep/mainTemplate.bicep
+++ b/weblogic-azure-aks/src/main/bicep/mainTemplate.bicep
@@ -229,6 +229,8 @@ param sslUploadedPrivateKeyPassPhrase string = newGuid()
 param t3ChannelAdminPort int = 7005
 @description('Public port of the custom T3 channel in WebLoigc cluster')
 param t3ChannelClusterPort int = 8011
+@description('True to use well-tesed Kubernetes version.')
+param useAksWellTestedVersion bool = true
 @description('True to set up internal load balancer service.')
 param useInternalLB bool = false
 @description('ture to upload Java EE applications and deploy the applications to WebLogic domain.')
@@ -334,6 +336,7 @@ module validateInputs 'modules/_deployment-scripts/_ds-validate-parameters.bicep
     aksAgentPoolVMSize: aksAgentPoolVMSize
     aksClusterRGName: aksClusterRGName
     aksClusterName: aksClusterName
+    aksVersion: aksVersion
     appGatewayCertificateOption: appGatewayCertificateOption
     appGatewaySSLCertData: appGatewaySSLCertData
     appGatewaySSLCertPassword: appGatewaySSLCertPassword
@@ -373,6 +376,7 @@ module validateInputs 'modules/_deployment-scripts/_ds-validate-parameters.bicep
     sslUploadedCustomTrustKeyStoreType: sslUploadedCustomTrustKeyStoreType
     sslUploadedPrivateKeyAlias: sslUploadedPrivateKeyAlias
     sslUploadedPrivateKeyPassPhrase: sslUploadedPrivateKeyPassPhrase
+    useAksWellTestedVersion: useAksWellTestedVersion
     userProvidedAcr: userProvidedAcr // used in user provided images
     userProvidedImagePath: userProvidedImagePath
     useOracleImage: useOracleImage
@@ -443,7 +447,7 @@ module wlsDomainDeployment 'modules/setupWebLogicCluster.bicep' = if (!enableCus
     aksClusterNamePrefix: aksClusterNamePrefix
     aksClusterRGName: aksClusterRGName
     aksClusterName: aksClusterName
-    aksVersion: aksVersion
+    aksVersion: validateInputs.outputs.aksVersion
     appPackageUrls: appPackageUrls
     appReplicas: appReplicas
     createAKSCluster: createAKSCluster
@@ -508,7 +512,7 @@ module wlsDomainWithCustomSSLDeployment 'modules/setupWebLogicCluster.bicep' = i
     aksClusterNamePrefix: aksClusterNamePrefix
     aksClusterRGName: aksClusterRGName
     aksClusterName: aksClusterName
-    aksVersion: aksVersion
+    aksVersion: validateInputs.outputs.aksVersion
     appPackageUrls: appPackageUrls
     appReplicas: appReplicas
     createAKSCluster: createAKSCluster

--- a/weblogic-azure-aks/src/main/bicep/modules/_deployment-scripts/_ds-validate-parameters.bicep
+++ b/weblogic-azure-aks/src/main/bicep/modules/_deployment-scripts/_ds-validate-parameters.bicep
@@ -6,6 +6,7 @@ param aksAgentPoolNodeCount int
 param aksAgentPoolVMSize string
 param aksClusterRGName string
 param aksClusterName string
+param aksVersion string
 param appGatewayCertificateOption string
 param appGatewaySSLCertData string
 @secure()
@@ -51,6 +52,7 @@ param sslUploadedCustomTrustKeyStoreType string
 param sslUploadedPrivateKeyAlias string
 @secure()
 param sslUploadedPrivateKeyPassPhrase string
+param useAksWellTestedVersion bool
 param userProvidedAcr string
 param userProvidedImagePath string
 param useOracleImage bool
@@ -98,6 +100,10 @@ resource deploymentScript 'Microsoft.Resources/deploymentScripts@2020-10-01' = {
       {
         name: 'AKS_CLUSTER_RESOURCEGROUP_NAME'
         value: aksClusterRGName
+      }
+      {
+        name: 'AKS_VERSION'
+        value: aksVersion
       }
       {
         name: 'BASE64_FOR_SERVICE_PRINCIPAL'
@@ -207,6 +213,10 @@ resource deploymentScript 'Microsoft.Resources/deploymentScripts@2020-10-01' = {
         name: 'DNA_ZONE_RESOURCEGROUP_NAME'
         value: dnszoneRGName
       }
+      {
+        name: 'USE_AKS_WELL_TESTED_VERSION'
+        value: string(useAksWellTestedVersion)
+      }
     ]
     scriptContent: format('{0}\r\n\r\n{1}', loadTextContent('../../../arm/scripts/common.sh'), loadTextContent('../../../arm/scripts/inline-scripts/validateParameters.sh'))
     cleanupPreference: 'OnSuccess'
@@ -214,3 +224,6 @@ resource deploymentScript 'Microsoft.Resources/deploymentScripts@2020-10-01' = {
     forceUpdateTag: utcValue
   }
 }
+
+
+output aksVersion string = reference(const_deploymentName).outputs.aksVersion

--- a/weblogic-azure-aks/src/test/setupWlsAksParameters.json
+++ b/weblogic-azure-aks/src/test/setupWlsAksParameters.json
@@ -59,7 +59,7 @@
             "value": false
         },
         "enableAzureFileShare": {
-            "value": false
+            "value": true
         },
         "enableCookieBasedAffinity": {
             "value": true


### PR DESCRIPTION
### Changes
1. Customize AKS version
    As current default AKS (1.22.6) has regression issues and causes PV/PVC failure and application gateway ingress failure in WLS on AKS offer. 
    @edburns  and I agreed to use a stable version in the offer to avoid such kind of potential exceptions in the future.    
    The well-tested version is saved in `aks-well-tested-version.json`, see #142 , current tested version is 1.21.9. We will test and update the AKS version periodically.

2. Enhance UI for domain home source type and clear pv/pvc statement 

3.  Test pv/pvc mounting in the pipeline
Enable PV/PVC mounting in the testing parameter file.

### Test cases
1. Use existing AKS instance -> deployed successfully
1. Use valid well-tested AKS version -> deployed successfully with the well-tested AKS version
2. Use invalid well-tested AKS version -> deployed successfully with the default AKS version
3. Input valid AKS version -> deployed successfully with the input AKS version
4. Input invalid AKS version -> failed.
5. Pipeline test with valid well-tested AKS version: https://github.com/galiacheng/weblogic-azure/actions/runs/2293347399
