### PR TITLE
Address issue 143: make PID works in forked repo

### DIFF
--- a/.github/workflows/buildWlsVm4AsArtifact.yml
+++ b/.github/workflows/buildWlsVm4AsArtifact.yml
@@ -16,17 +16,33 @@ on:
         required: false
         default: 'refs/heads/main'
   # Sample cURL
-  # curl --verbose -X POST https://api.github.com/repos/<github_user>/weblogic-azure/dispatches -H 'Accept: application/vnd.github.everest-preview+json' -H 'Authorization: token <personal_access_token>' --data '{"event_type": "vms-admin-package}'
+  # curl --verbose -X POST https://api.github.com/repos/<github_user>/weblogic-azure/dispatches -H 'Accept: application/vnd.github.everest-preview+json' -H 'Authorization: token <personal_access_token>' --data '{"event_type": "vms-admin-package",  "client_payload": {"pidType": "microsoft", "ref": "refs/heads/main"}}'
 env:
   refArmttk: 7dc2c2a7822c2825ea3524ac2af72e561847fece
   refJavaee: 062fe0eb4e72012ead98c23e1a1b2c6259e7e7c4
   offerName: "arm-oraclelinux-wls-admin"
   repoName: "weblogic-azure"
+  repoOwner: ${{ secrets.USER_NAME }}
 
 jobs:
   package:
     runs-on: ubuntu-latest
     steps:
+      - name: Setup environment variables
+        id: setup-env-variables-based-on-dispatch-event
+        run: |
+          ref='refs/heads/main'
+          if [ ${{ github.event_name }} == 'workflow_dispatch' ]; then
+            pidType=${{ github.event.inputs.pidType }}
+            ref=${{ github.event.inputs.ref }}
+          else
+            pidType=${{ github.event.client_payload.pidType }}
+            ref=${{ github.event.client_payload.ref }}
+          fi
+          echo "##[set-output name=pidType;]${pidType}"
+          echo "##[set-output name=ref;]${ref}"
+          echo "pidType=${pidType}" >> $GITHUB_ENV
+          echo "ref=${ref}" >> $GITHUB_ENV
       - name: Checkout azure-javaee-iaas
         uses: actions/checkout@v2
         with:
@@ -43,7 +59,7 @@ jobs:
         uses: actions/checkout@v2
         with:
           path: ${{ env.repoName }}
-          ref: ${{ github.event.inputs.ref }}
+          ref: ${{ env.ref }}
       - name: Set up JDK 1.8
         uses: actions/setup-java@v1
         with:
@@ -54,16 +70,16 @@ jobs:
         run:  |
            cd ${{env.repoName}}/weblogic-azure-vm/${{ env.offerName }}
            find . -name "*.json" | xargs sed -i 's|../../../../utilities|../utilities|g' $1
-      - name: Build and test ${{ env.offerName }} using ${{ github.event.inputs.pidType }} pids
+      - name: Build and test ${{ env.offerName }} using ${{ env.pidType }} pids
         run: |
           cd ${{env.repoName}}/weblogic-azure-vm/${{ env.offerName }}
-          pidType=${{ github.event.inputs.pidType }}
+          pidType=${{ env.pidType }}
           if [[ "${pidType}" == "oracle" ]];then
             echo "using oracle pid"
-            mvn -Ptemplate-validation-tests clean install
+            mvn -Ptemplate-validation-tests clean install -Dgit.repo.owner=${{ env.repoOwner }} -Dgit.tag=${{ env.ref }}
           else
             echo "using ms pid"
-            mvn -Ptemplate-validation-tests clean install -Ddev
+            mvn -Ptemplate-validation-tests clean install -Ddev -Dgit.repo.owner=${{ env.repoOwner }} -Dgit.tag=${{ env.ref }}
           fi
 
       - name: Generate artifact file name and path
@@ -73,7 +89,7 @@ jobs:
           version=$(awk '/<version>[^<]+<\/version>/{gsub(/<version>|<\/version>/,"",$1);print $1;exit;}' pom.xml)
           artifactName=${{ env.offerName }}-$version-arm-assembly
           unzip target/$artifactName.zip -d target/$artifactName
-          echo "##[set-output name=artifactName;]${artifactName}-${{ github.event.inputs.pidType }}"
+          echo "##[set-output name=artifactName;]${artifactName}-${{ env.pidType }}"
           echo "##[set-output name=artifactPath;]${{env.repoName}}/weblogic-azure-vm/${{ env.offerName }}/target/$artifactName"
       - name: Archive ${{ env.offerName }} template
         uses: actions/upload-artifact@v1

--- a/.github/workflows/buildWlsVm4AsArtifact.yml
+++ b/.github/workflows/buildWlsVm4AsArtifact.yml
@@ -31,7 +31,6 @@ jobs:
       - name: Setup environment variables
         id: setup-env-variables-based-on-dispatch-event
         run: |
-          ref='refs/heads/main'
           if [ ${{ github.event_name }} == 'workflow_dispatch' ]; then
             pidType=${{ github.event.inputs.pidType }}
             ref=${{ github.event.inputs.ref }}
@@ -39,6 +38,15 @@ jobs:
             pidType=${{ github.event.client_payload.pidType }}
             ref=${{ github.event.client_payload.ref }}
           fi
+
+          if [ -z "$pidType" ]; then
+            pidType='microsoft'
+          fi
+
+          if [ -z "$ref" ]; then
+            ref='refs/heads/main'
+          fi
+
           echo "##[set-output name=pidType;]${pidType}"
           echo "##[set-output name=ref;]${ref}"
           echo "pidType=${pidType}" >> $GITHUB_ENV

--- a/.github/workflows/newtag.yml
+++ b/.github/workflows/newtag.yml
@@ -15,7 +15,7 @@ on:
   # sample cURL
   # curl --verbose -X POST https://api.github.com/repos/<github_user>/weblogic-azure/dispatches -H 'Accept: application/vnd.github.everest-preview+json' -H 'Authorization: token <personal_access_token>' --data '<request_data>'
   # sample <request_data>
-  # {"event_type": "gh-pages-newtag, "client_payload": {"tagname": "2021-12-09-02-Q4" }}
+  # {"event_type": "gh-pages-newtag", "client_payload": {"tagname": "2021-12-09-02-Q4", "ref": "refs/heads/main" }}
 
 env:
   tagbranch: "tagbranch"
@@ -40,6 +40,14 @@ jobs:
           else
             tagname=${{ github.event.client_payload.tagname }}
             ref=${{ github.event.client_payload.ref }}
+          fi
+
+          if [ -z "$tagname" ]; then
+            tagname=${userName}`date +%m%d`
+          fi
+
+          if [ -z "$ref" ]; then
+            ref='refs/heads/main'
           fi
 
           echo "##[set-output name=tagname;]${tagname}"

--- a/.github/workflows/newtag.yml
+++ b/.github/workflows/newtag.yml
@@ -59,7 +59,8 @@ jobs:
         uses: actions/checkout@v2
         with:
           path: ${{ env.repoName }}
-          ref: ${{ github.event.inputs.ref }}
+          ref: ${{ env.ref }}
+          token: ${{ env.gitToken }}
       - name: Checkout azure-javaee-iaas
         uses: actions/checkout@v2
         with:

--- a/.github/workflows/newtag.yml
+++ b/.github/workflows/newtag.yml
@@ -25,6 +25,7 @@ env:
   repoName: "weblogic-azure"
   userEmail: ${{ secrets.USER_EMAIL }}
   userName: ${{ secrets.USER_NAME }}
+  repoOwner: ${{ secrets.USER_NAME }}
 
 jobs:
   newtag:
@@ -80,7 +81,7 @@ jobs:
         run: |
           cd ${{ env.repoName }}
           mvn -Ptemplate-validation-tests clean install --file weblogic-azure-vm/arm-oraclelinux-wls/pom.xml
-          mvn -Ptemplate-validation-tests clean install --file weblogic-azure-vm/arm-oraclelinux-wls-admin/pom.xml
+          mvn -Ptemplate-validation-tests clean install --file weblogic-azure-vm/arm-oraclelinux-wls-admin/pom.xml -Dgit.repo.owner=${{ env.repoOwner }} -Dgit.tag=${{ env.ref }}
           mvn -Ptemplate-validation-tests clean install --file weblogic-azure-vm/arm-oraclelinux-wls-cluster/pom.xml
           mvn -Ptemplate-validation-tests clean install --file weblogic-azure-vm/arm-oraclelinux-wls-dynamic-cluster/pom.xml
 

--- a/.github/workflows/testWlsVmAdmin.yml
+++ b/.github/workflows/testWlsVmAdmin.yml
@@ -10,10 +10,14 @@ on:
         description: "Specify whether to enable ELK depoyment or not."
         required: true
         default: "false"
+      ref:
+        description: 'Specify Git Ref if needed.'
+        required: false
+        default: 'refs/heads/main'
   # Allows you to run this workflow using GitHub APIs
   # PERSONAL_ACCESS_TOKEN=<GITHUB_PERSONAL_ACCESS_TOKEN>
-  # REPO_NAME=mriccell/arm-oraclelinux-wls-admin
-  # curl --verbose -XPOST -u "mriccell:${PERSONAL_ACCESS_TOKEN}" -H "Accept: application/vnd.github.everest-preview+json" -H "Content-Type: application/json" https://api.github.com/repos/${REPO_NAME}/dispatches --data '{"event_type": "test-vm-admin"}'
+  # REPO_NAME=mriccell/weblogic-azure
+  # curl --verbose -XPOST -u "mriccell:${PERSONAL_ACCESS_TOKEN}" -H "Accept: application/vnd.github.everest-preview+json" -H "Content-Type: application/json" https://api.github.com/repos/${REPO_NAME}/dispatches --data '{"event_type": "test-vm-admin", "client_payload": {"enableELK": "false", "ref": "refs/heads/main"}}'
   repository_dispatch:
     types: [test-vm-admin,integration-test-all]
 
@@ -45,8 +49,25 @@ env:
 
 jobs:
   preflight:
+    outputs:
+      enableELK: ${{ steps.setup-env-variables-based-on-dispatch-event.outputs.enableELK }}
     runs-on: ubuntu-latest
     steps:
+      - name: Setup environment variables
+        id: setup-env-variables-based-on-dispatch-event
+        run: |
+          ref='refs/heads/main'
+          if [ ${{ github.event_name }} == 'workflow_dispatch' ]; then
+            enableELK=${{ github.event.inputs.enableELK }}
+            ref=${{ github.event.inputs.ref }}
+          else
+            enableELK=${{ github.event.client_payload.enableELK }}
+            ref=${{ github.event.client_payload.ref }}
+          fi
+          echo "##[set-output name=enableELK;]${enableELK}"
+          echo "##[set-output name=ref;]${ref}"
+          echo "enableELK=${enableELK}" >> $GITHUB_ENV
+          echo "ref=${ref}" >> $GITHUB_ENV
       - name: Checkout azure-javaee-iaas
         uses: actions/checkout@v2
         with:
@@ -63,6 +84,7 @@ jobs:
         uses: actions/checkout@v2
         with:
           repository: ${{env.repoOwner}}/${{env.repoName}}
+          ref: ${{ env.ref }}
           path: ${{env.repoName}}
       - name: Set up JDK 1.8
         uses: actions/setup-java@v1
@@ -73,7 +95,7 @@ jobs:
       - name: Build and test ${{ env.offerName }}
         run: |
           ls
-          mvn -Ptemplate-validation-tests clean install --file ${adminOfferPath}/pom.xml
+          mvn -Ptemplate-validation-tests clean install -Dgit.repo.owner=${{ env.repoOwner }} -Dgit.tag=${{ env.ref }} --file ${adminOfferPath}/pom.xml
 
       - name: Checkout ${{env.repoOwner}}/${{env.repoName}} for test
         uses: actions/checkout@v2
@@ -417,7 +439,7 @@ jobs:
 
       - name: Set up ELK by deploying sub template
         id: enable-elk
-        if: ${{github.event_name == 'workflow_dispatch' && github.event.inputs.enableELK == 'true'}}
+        if: ${{ needs.preflight.outputs.enableELK == 'true' }}
         run: |
             # Generate parameters for ELK template deployment
             bash ${{ env.adminOfferPath }}/test/scripts/gen-parameters-deploy-elk.sh \
@@ -442,13 +464,12 @@ jobs:
             --template-file ${artifactName}/nestedtemplates/elkNestedTemplate.json
       - name: Delete Resource Group
         id: delete-resource-group
-        if: always()
         run: |
             echo "delete... " $resourceGroup
             az group delete --yes --no-wait --verbose --name $resourceGroup
       - name: Delete ELK index
         id: delete-elk-index
-        if: ${{github.event_name == 'workflow_dispatch' && github.event.inputs.enableELK == 'true'}}
+        if: ${{ needs.preflight.outputs.enableELK == 'true' }}
         run: |
           curl -XDELETE --user ${{ env.elkUser }}:${{ env.elkPassword }}  ${{ env.elkURI }}/azure-weblogic-admin-${{ github.run_id }}${{ github.run_number }}
 

--- a/.github/workflows/testWlsVmAdmin.yml
+++ b/.github/workflows/testWlsVmAdmin.yml
@@ -56,7 +56,6 @@ jobs:
       - name: Setup environment variables
         id: setup-env-variables-based-on-dispatch-event
         run: |
-          ref='refs/heads/main'
           if [ ${{ github.event_name }} == 'workflow_dispatch' ]; then
             enableELK=${{ github.event.inputs.enableELK }}
             ref=${{ github.event.inputs.ref }}
@@ -64,6 +63,15 @@ jobs:
             enableELK=${{ github.event.client_payload.enableELK }}
             ref=${{ github.event.client_payload.ref }}
           fi
+
+          if [ -z "$enableELK" ]; then
+            enableELK='false'
+          fi
+
+          if [ -z "$ref" ]; then
+            ref='refs/heads/main'
+          fi
+
           echo "##[set-output name=enableELK;]${enableELK}"
           echo "##[set-output name=ref;]${ref}"
           echo "enableELK=${enableELK}" >> $GITHUB_ENV

--- a/weblogic-azure-vm/arm-oraclelinux-wls-admin/admin-ssl-post-deploy/pom.xml
+++ b/weblogic-azure-vm/arm-oraclelinux-wls-admin/admin-ssl-post-deploy/pom.xml
@@ -10,7 +10,7 @@
 
     <groupId>com.oracle.weblogic.azure</groupId>
     <artifactId>arm-oraclelinux-wls-admin-ssl-config-post-deploy</artifactId>
-    <version>1.0.24</version>
+    <version>1.0.30</version>
     
     <parent>
         <groupId>com.microsoft.azure.iaas</groupId>
@@ -23,11 +23,14 @@
     <name>${project.artifactId}</name>
 
     <properties>
-        <artifactsLocationBase>https://raw.githubusercontent.com/oracle/${git.repo}/${git.tag}/weblogic-azure-vm</artifactsLocationBase>
+        <git.tag>main</git.tag>
+        <git.repo>weblogic-azure</git.repo>
+        <git.repo.owner>oracle</git.repo.owner>
+        <artifactsLocationBase>https://raw.githubusercontent.com/${git.repo.owner}/${git.repo}/${git.tag}/weblogic-azure-vm</artifactsLocationBase>
         <template.validation.tests.directory>${basedir}/../../../../arm-ttk/arm-ttk</template.validation.tests.directory>
         <test.parameters>-TestParameter '@{&quot;SampleName&quot;=&quot;admin-ssl-post-deploy/src/main&quot;;&quot;RawRepoPath&quot;=&quot;${artifactsLocationBase}/arm-oraclelinux-wls-admin/&quot;}'</test.parameters>
-        <template.pid.properties.url>https://raw.githubusercontent.com/oracle/weblogic-azure/main/weblogic-azure-vm/arm-oraclelinux-wls/src/main/resources/pid.properties</template.pid.properties.url>
-        <template.microsoft.pid.properties.url>https://raw.githubusercontent.com/oracle/weblogic-azure/main/weblogic-azure-vm/arm-oraclelinux-wls/src/main/resources/microsoft-pid.properties</template.microsoft.pid.properties.url>
+        <template.pid.properties.url>https://raw.githubusercontent.com/${git.repo.owner}/weblogic-azure/${git.tag}/weblogic-azure-vm/arm-oraclelinux-wls/src/main/resources/pid.properties</template.pid.properties.url>
+        <template.microsoft.pid.properties.url>https://raw.githubusercontent.com/${git.repo.owner}/weblogic-azure/${git.tag}/weblogic-azure-vm/arm-oraclelinux-wls/src/main/resources/microsoft-pid.properties</template.microsoft.pid.properties.url>
     </properties>
 
     <description>

--- a/weblogic-azure-vm/arm-oraclelinux-wls-admin/pom.xml
+++ b/weblogic-azure-vm/arm-oraclelinux-wls-admin/pom.xml
@@ -10,7 +10,7 @@
 
     <groupId>com.oracle.weblogic.azure</groupId>
     <artifactId>arm-oraclelinux-wls-admin</artifactId>
-    <version>1.0.27</version>
+    <version>1.0.30</version>
     
     <parent>
         <groupId>com.microsoft.azure.iaas</groupId>
@@ -21,11 +21,14 @@
     <packaging>pom</packaging>
     <name>${project.artifactId}</name>
     <properties>
-        <artifactsLocationBase>https://raw.githubusercontent.com/oracle/${git.repo}/${git.tag}/weblogic-azure-vm</artifactsLocationBase>
+        <git.tag>main</git.tag>
+        <git.repo>weblogic-azure</git.repo>
+        <git.repo.owner>oracle</git.repo.owner>
+        <artifactsLocationBase>https://raw.githubusercontent.com/${git.repo.owner}/${git.repo}/${git.tag}/weblogic-azure-vm</artifactsLocationBase>
         <template.validation.tests.directory>${basedir}/../../../arm-ttk/arm-ttk</template.validation.tests.directory>
         <test.parameters>-TestParameter '@{&quot;PasswordMinLength&quot;=5}'</test.parameters>
-        <template.pid.properties.url>https://raw.githubusercontent.com/oracle/weblogic-azure/main/weblogic-azure-vm/arm-oraclelinux-wls/src/main/resources/pid.properties</template.pid.properties.url>
-        <template.microsoft.pid.properties.url>https://raw.githubusercontent.com/oracle/weblogic-azure/main/weblogic-azure-vm/arm-oraclelinux-wls/src/main/resources/microsoft-pid.properties</template.microsoft.pid.properties.url>
+        <template.pid.properties.url>https://raw.githubusercontent.com/${git.repo.owner}/weblogic-azure/${git.tag}/weblogic-azure-vm/arm-oraclelinux-wls/src/main/resources/pid.properties</template.pid.properties.url>
+        <template.microsoft.pid.properties.url>https://raw.githubusercontent.com/${git.repo.owner}/weblogic-azure/${git.tag}/weblogic-azure-vm/arm-oraclelinux-wls/src/main/resources/microsoft-pid.properties</template.microsoft.pid.properties.url>
     </properties>
     
     <modules>

--- a/weblogic-azure-vm/arm-oraclelinux-wls-admin/src/main/arm/mainTemplate.json
+++ b/weblogic-azure-vm/arm-oraclelinux-wls-admin/src/main/arm/mainTemplate.json
@@ -1219,11 +1219,11 @@
       },
       "adminConsoleURL": {
          "type": "string",
-         "value": "[if(parameters('enableCustomDNS'),format('http://{0}.{1}:7001/console',parameters('dnszoneAdminConsoleLabel'),parameters('dnszoneName')),reference(variables('name_adminLinkedTemplateDeployment'),'${azure.apiVersion}').outputs.adminConsoleURL.value)]"
+         "value": "[if(parameters('enableCustomDNS'), uri(format('http://{0}.{1}:7001/console',parameters('dnszoneAdminConsoleLabel'),parameters('dnszoneName')), '/'),reference(variables('name_adminLinkedTemplateDeployment'),'${azure.apiVersion}').outputs.adminConsoleURL.value)]"
       },
       "adminConsoleSecureURL": {
          "type": "string",
-         "value": "[if(parameters('enableCustomDNS'),format('https://{0}.{1}:7002/console',parameters('dnszoneAdminConsoleLabel'),parameters('dnszoneName')),reference(variables('name_adminLinkedTemplateDeployment'),'${azure.apiVersion}').outputs.adminConsoleSecureURL.value)]"
+         "value": "[if(parameters('enableCustomDNS'), uri(format('https://{0}.{1}:7002/console',parameters('dnszoneAdminConsoleLabel'),parameters('dnszoneName')), '/'),reference(variables('name_adminLinkedTemplateDeployment'),'${azure.apiVersion}').outputs.adminConsoleSecureURL.value)]"
       },
       "logIndex": {
          "type": "string",

--- a/weblogic-azure-vm/arm-oraclelinux-wls-admin/src/main/arm/nestedtemplates/adminTemplate.json
+++ b/weblogic-azure-vm/arm-oraclelinux-wls-admin/src/main/arm/nestedtemplates/adminTemplate.json
@@ -730,11 +730,11 @@
       },
       "adminConsoleURL": {
          "type": "string",
-         "value": "[concat('http://', if(equals(parameters('virtualNetworkNewOrExisting'), 'new'), reference(variables('name_publicIPAddress')).dnsSettings.fqdn, reference(variables('name_nic_without_pub_ip')).ipConfigurations[0].properties.privateIPAddress),':7001/console')]"
+         "value": "[uri(concat('http://', if(equals(parameters('virtualNetworkNewOrExisting'), 'new'), reference(variables('name_publicIPAddress')).dnsSettings.fqdn, reference(variables('name_nic_without_pub_ip')).ipConfigurations[0].properties.privateIPAddress),':7001/console'), '/')]"
       },
       "adminConsoleSecureURL": {
          "type": "string",
-         "value": "[concat('https://',if(equals(parameters('virtualNetworkNewOrExisting'), 'new'), reference(variables('name_publicIPAddress')).dnsSettings.fqdn, reference(variables('name_nic_without_pub_ip')).ipConfigurations[0].properties.privateIPAddress),':7002/console')]"
+         "value": "[uri(concat('https://',if(equals(parameters('virtualNetworkNewOrExisting'), 'new'), reference(variables('name_publicIPAddress')).dnsSettings.fqdn, reference(variables('name_nic_without_pub_ip')).ipConfigurations[0].properties.privateIPAddress),':7002/console'), '/')]"
       }
    }
 }

--- a/weblogic-azure-vm/arm-oraclelinux-wls-admin/src/main/arm/nestedtemplates/adminTemplateForCustomSSL.json
+++ b/weblogic-azure-vm/arm-oraclelinux-wls-admin/src/main/arm/nestedtemplates/adminTemplateForCustomSSL.json
@@ -785,11 +785,11 @@
       },
       "adminConsoleURL": {
          "type": "string",
-         "value": "[concat('http://', if(equals(parameters('virtualNetworkNewOrExisting'), 'new'), reference(variables('name_publicIPAddress')).dnsSettings.fqdn, reference(variables('name_nic_without_pub_ip')).ipConfigurations[0].properties.privateIPAddress),':7001/console')]"
+         "value": "[uri(concat('http://', if(equals(parameters('virtualNetworkNewOrExisting'), 'new'), reference(variables('name_publicIPAddress')).dnsSettings.fqdn, reference(variables('name_nic_without_pub_ip')).ipConfigurations[0].properties.privateIPAddress),':7001/console'), '/')]"
       },
       "adminConsoleSecureURL": {
          "type": "string",
-         "value": "[concat('https://',if(equals(parameters('virtualNetworkNewOrExisting'), 'new'), reference(variables('name_publicIPAddress')).dnsSettings.fqdn, reference(variables('name_nic_without_pub_ip')).ipConfigurations[0].properties.privateIPAddress),':7002/console')]"
+         "value": "[uri(concat('https://',if(equals(parameters('virtualNetworkNewOrExisting'), 'new'), reference(variables('name_publicIPAddress')).dnsSettings.fqdn, reference(variables('name_nic_without_pub_ip')).ipConfigurations[0].properties.privateIPAddress),':7002/console'), '/')]"
       }
    }
 }

--- a/weblogic-azure-vm/arm-oraclelinux-wls-admin/src/main/scripts/setupAdminDomain.sh
+++ b/weblogic-azure-vm/arm-oraclelinux-wls-admin/src/main/scripts/setupAdminDomain.sh
@@ -315,12 +315,6 @@ function validateInput()
     then
         echo_stderr "virtualNetworkNewOrExisting is required. "
         exit 1
-    else
-        if [ "${virtualNetworkNewOrExisting,,}" != "existing" ];
-        then
-            # If deploying to an existing VNET, using private IP instead of hostname
-            wlsAdminHost=${adminPublicHostName}
-        fi
     fi
 
     if [ -z "$storageAccountPrivateIp" ];

--- a/weblogic-azure-vm/arm-oraclelinux-wls/src/main/resources/microsoft-pid.properties
+++ b/weblogic-azure-vm/arm-oraclelinux-wls/src/main/resources/microsoft-pid.properties
@@ -6,7 +6,7 @@ azure.apiVersion2=2021-06-01
 azure.apiVersionForDeploymentScript=2020-10-01
 azure.apiVersionForDNSZone=2018-05-01
 azure.apiVersionForIndentity=2018-11-30
-azure.apiVersionForKeyVault=2019-09-01
+azure.apiVersionForKeyVault=2021-10-01
 azure.apiVersionForPrivateEndpoint=2021-05-01
 
 # Values in this file are read at build time for the other Azure Marketplace offer repositories

--- a/weblogic-azure-vm/arm-oraclelinux-wls/src/main/resources/pid.properties
+++ b/weblogic-azure-vm/arm-oraclelinux-wls/src/main/resources/pid.properties
@@ -6,7 +6,8 @@ azure.apiVersion2=2021-06-01
 azure.apiVersionForDeploymentScript=2020-10-01
 azure.apiVersionForDNSZone=2018-05-01
 azure.apiVersionForIndentity=2018-11-30
-azure.apiVersionForKeyVault=2019-09-01
+azure.apiVersionForKeyVault=2021-10-01
+azure.apiVersionForPrivateEndpoint=2021-05-01
 
 
 # Values in this file are read at build time for the other Azure Marketplace offer repositories


### PR DESCRIPTION
#143 

Changes:
* Make PID works in forked repo
    * Update pom.xml files to parameterized PID reference
    * Update pipelines to pass parameters of forked repo
* Support both workflow_dispatch and repo_dispatch for `buildWlsVm4AsArtifact.yml` and `testWlsVmAdmin.yml`
* Update Admin offer version
* Improvement and bugs found by PR and addressed
    * Improve URL creation in templates based on errors got from arm-ttk, [related issue](https://github.com/Azure/arm-ttk/issues/590)
    * Upgrade Key Vault API version based on arm-ttk error, add private end point to Oracle pid
    * Located a bug and fixed: unused logic broke accessing admin console via port 7005

Test:
* Pipelines
    * [testWlsVmAdmin.ym](https://github.com/zhengchang907/weblogic-azure/actions/runs/2390465962)
    * [buildWlsVm4AsArtifact.yml](https://github.com/zhengchang907/weblogic-azure/actions/workflows/buildWlsVm4AsArtifact.yml)
    * [NewTag](https://github.com/zhengchang907/weblogic-azure/actions/workflows/newtag.yml)
* Admin offer
    * Template deployment cases
        * No SSL, new VNET
        * No SSL, existing VNET(use zheng-private-vnet)
        * SSL, new VNET
        * SSL, existing VNET(use zheng-private-vnet)
    * [Private offer](https://portal.azure.com/#create/microsoft_javaeeonazure_test.20210105-zhengchang-01-preview2021-zheng-admin-test) deployment cases 
        * No SSL, new VNET
        * No SSL, existing VNET(use zheng-private-vnet)
        * SSL, new VNET
        * SSL, existing VNET(use zheng-private-vnet)
