### PR TITLE
Fix some observed issues

### DIFF
--- a/weblogic-azure-aks/src/main/arm/createUiDefinition.json
+++ b/weblogic-azure-aks/src/main/arm/createUiDefinition.json
@@ -1576,7 +1576,7 @@
                                 "visible": "[steps('section_appGateway').appgwIngress.enableAppGateway]",
                                 "options": {
                                     "icon": "Info",
-                                    "text": "You must input an Active Directory Service Principal that is encoded with base64 to create the Application Gateway Ingress Controller. See this <a href=https://aka.ms/wls-aks-agic-sp-doc target='_blank'>document</a> for more information.</br>You can generate one with command <b>az ad sp create-for-rbac --role Contributor --sdk-auth | base64 -w0</b>. On macOS omit the <b>-w0</b>."
+                                    "text": "You must input an Active Directory Service Principal that is encoded with base64 to create the Application Gateway Ingress Controller. See this <a href=https://aka.ms/wls-aks-agic-sp-doc target='_blank'>document</a> for more information.</br>You can generate one with command <b>az ad sp create-for-rbac --sdk-auth --role Contributor --scopes /subscriptions/&lt;AZURE_SUBSCRIPTION_ID&gt; | base64 -w0</b>. On macOS omit the <b>-w0</b>."
                                 }
                             },
                             {
@@ -1586,7 +1586,7 @@
                                     "password": "Service Principal",
                                     "confirmPassword": "Confirm password"
                                 },
-                                "toolTip": "Base64 encoded JSON blob of the service principal. You can generate one with command 'az ad sp create-for-rbac --role Contributor --sdk-auth | base64 -w0' On macOS omit the -w0.",
+                                "toolTip": "Base64 encoded JSON blob of the service principal. You can generate one with command 'az ad sp create-for-rbac --sdk-auth --role Contributor --scopes /subscriptions/&lt;AZURE_SUBSCRIPTION_ID&gt; | base64 -w0' On macOS omit the -w0.",
                                 "constraints": {
                                     "required": true
                                 },

--- a/weblogic-azure-aks/src/main/arm/createUiDefinition.json
+++ b/weblogic-azure-aks/src/main/arm/createUiDefinition.json
@@ -1584,7 +1584,7 @@
                                 "type": "Microsoft.Common.PasswordBox",
                                 "label": {
                                     "password": "Service Principal",
-                                    "confirmPassword": "Confirm password"
+                                    "confirmPassword": "Confirm service principal"
                                 },
                                 "toolTip": "Base64 encoded JSON blob of the service principal. You can generate one with command 'az ad sp create-for-rbac --sdk-auth --role Contributor --scopes /subscriptions/&lt;AZURE_SUBSCRIPTION_ID&gt; | base64 -w0' On macOS omit the -w0.",
                                 "constraints": {

--- a/weblogic-azure-aks/src/main/bicep/mainTemplate.bicep
+++ b/weblogic-azure-aks/src/main/bicep/mainTemplate.bicep
@@ -162,7 +162,7 @@ param ocrSSOPSW string = newGuid()
 @description('User name of Oracle SSO account.')
 param ocrSSOUser string = 'null'
 @secure()
-@description('Base64 string of service principal. use the command to generate a testing string: az ad sp create-for-rbac --sdk-auth | base64 -w0')
+@description('Base64 string of service principal. use the command to generate a testing string: az ad sp create-for-rbac --sdk-auth --role Contributor --scopes /subscriptions/<AZURE_SUBSCRIPTION_ID> | base64 -w0')
 param servicePrincipal string = newGuid()
 @allowed([
   'uploadConfig'


### PR DESCRIPTION
The PR is to fix the following issues:
* The new version of Azure CLI `az ad sp create-for-rbac` requires specifying `--scope` if `--role` is specified. Fixed by appending `--scope` to help text.
* The certificate downloaded to file using `az keyvault secret download` doesn't have the expected format (base64 encoded), which caused the validation failure. Fixed by replacing `az keyvault secret download` with `az keyvault secret show`.
  * The relevant error message: 
     ```
    Error message: line 507: warning: command substitution: ignored null byte in input base64: truncated base64 input 140593951247688:error:0D0680A8:asn1 encoding routines:asn1_check_tlen:wrong tag:crypto/asn1/tasn_dec.c:1130: 140593951247688:error:0D07803A:asn1 encoding routines:asn1_item_embed_d2i:nested asn1 error:crypto/asn1/tasn_dec.c:290:Type=PKCS12 Errors happen during: access application gateway frontend key.. Make sure the Application Gateway frontend certificate is correct.
     ```  

Below is the way to prepare an Azure keyvault which contains the certificate data used for testing:
```
openssl genrsa -passout pass:<password> -out privkey.pem 3072
openssl req -x509 -new -key privkey.pem -out privkey.pub -subj "/C=US"
openssl pkcs12 -passout pass:<password> -export -in privkey.pub -inkey privkey.pem -out appgw-frontend-cert.pfx

az group create -n <keyvault-rg> -l eastus
az keyvault create --verbose --name <keyvaul-name> --resource-group <keyvault-rg> --location eastus
az keyvault update --verbose --name <keyvaul-name> --resource-group <keyvault-rg> --enabled-for-template-deployment true
az keyvault secret set --verbose --vault-name <keyvaul-name> --name myCertData --file appgw-frontend-cert.pfx --encoding base64
az keyvault secret set --verbose --vault-name <keyvaul-name> --name myCertPass --value <password>
```

Signed-off-by: Jianguo Ma <jiangma@microsoft.com>