### PR TITLE
Update WKO, WDT and WIT version

### DIFF
--- a/weblogic-azure-aks/src/main/arm/scripts/buildWLSDockerImage.sh
+++ b/weblogic-azure-aks/src/main/arm/scripts/buildWLSDockerImage.sh
@@ -167,10 +167,10 @@ function install_utilities() {
     curl -m ${curlMaxTime} -fL ${witDownloadURL} -o imagetool.zip
     validate_status "Check status of imagetool.zip."
 
-    curl -m ${curlMaxTime} -fL ${wlsPostgresqlDriverUrl} -o ${scriptDir}/model-images/wlsdeploy/domainLibraries/postgresql-42.2.8.jar
+    curl -m ${curlMaxTime} -fL ${wlsPostgresqlDriverUrl} -o ${scriptDir}/model-images/wlsdeploy/domainLibraries/${constPostgreDriverName}
     validate_status "Install postgresql driver."
 
-    curl -m ${curlMaxTime} -fL ${wlsMSSQLDriverUrl} -o ${scriptDir}/model-images/wlsdeploy/domainLibraries/mssql-jdbc-7.4.1.jre8.jar
+    curl -m ${curlMaxTime} -fL ${wlsMSSQLDriverUrl} -o ${scriptDir}/model-images/wlsdeploy/domainLibraries/${constMSSQLDriverName}
     validate_status "Install mssql driver."
 }
 
@@ -323,11 +323,6 @@ export dbDriversUrls=${12}
 
 export acrImagePath="$azureACRServer/aks-wls-images:${imageTag}"
 export dbDriverPaths=""
-export ocrLoginServer="container-registry.oracle.com"
-export wdtDownloadURL="https://github.com/oracle/weblogic-deploy-tooling/releases/download/release-1.9.17/weblogic-deploy.zip"
-export witDownloadURL="https://github.com/oracle/weblogic-image-tool/releases/download/release-1.9.16/imagetool.zip"
-export wlsPostgresqlDriverUrl="https://jdbc.postgresql.org/download/postgresql-42.3.6.jar"
-export wlsMSSQLDriverUrl="https://repo.maven.apache.org/maven2/com/microsoft/sqlserver/mssql-jdbc/10.2.1.jre8/mssql-jdbc-10.2.1.jre8.jar"
 
 read_sensitive_parameters_from_stdin
 

--- a/weblogic-azure-aks/src/main/arm/scripts/buildWLSDockerImage.sh
+++ b/weblogic-azure-aks/src/main/arm/scripts/buildWLSDockerImage.sh
@@ -183,6 +183,11 @@ function install_utilities() {
     unzip --help
     validate_status "Check status of unzip."
 
+    sudo apt-get -y -q install jq
+    echo "jq version"
+    jq --help
+    validate_status "Check status of unzip."
+
     download_wdt_wit
 
     curl -m ${curlMaxTime} -fL ${wlsPostgresqlDriverUrl} -o ${scriptDir}/model-images/wlsdeploy/domainLibraries/${constPostgreDriverName}

--- a/weblogic-azure-aks/src/main/arm/scripts/common.sh
+++ b/weblogic-azure-aks/src/main/arm/scripts/common.sh
@@ -19,6 +19,8 @@ export constDefaultAKSVersion="default"
 export constFalse="false"
 export constTrue="true"
 export constIntrospectorJobActiveDeadlineSeconds=300  # for Guaranteed Qos
+export constPostgreDriverName="postgresql-42.3.6.jar"
+export constMSSQLDriverName="mssql-jdbc-10.2.1.jre8.jar"
 
 export curlMaxTime=120 # seconds
 export ocrLoginServer="container-registry.oracle.com"
@@ -31,3 +33,7 @@ export optUninstallMaxTry=5 # Max attempts to wait for the operator uninstalled
 export optUninstallInterval=10
 
 export wlsContainerName="weblogic-server"
+export wdtDownloadURL="https://github.com/oracle/weblogic-deploy-tooling/releases/download/release-1.9.17/weblogic-deploy.zip"
+export witDownloadURL="https://github.com/oracle/weblogic-image-tool/releases/download/release-1.9.16/imagetool.zip"
+export wlsPostgresqlDriverUrl="https://jdbc.postgresql.org/download/postgresql-42.3.6.jar"
+export wlsMSSQLDriverUrl="https://repo.maven.apache.org/maven2/com/microsoft/sqlserver/mssql-jdbc/10.2.1.jre8/mssql-jdbc-10.2.1.jre8.jar"

--- a/weblogic-azure-aks/src/main/arm/scripts/common.sh
+++ b/weblogic-azure-aks/src/main/arm/scripts/common.sh
@@ -28,12 +28,11 @@ export ocrGaImagePath="middleware/weblogic"
 export ocrCpuImagePath="middleware/weblogic_cpu"
 export gitUrl4CpuImages="https://raw.githubusercontent.com/oracle/weblogic-azure/main/weblogic-azure-aks/src/main/resources/weblogic_cpu_images.json"
 export gitUrl4AksWellTestedVersionJsonFile="https://raw.githubusercontent.com/oracle/weblogic-azure/main/weblogic-azure-aks/src/main/resources/aks_well_tested_version.json"
+export gitUrl4WLSToolingFamilyJsonFile="https://raw.githubusercontent.com/galiacheng/weblogic-azure/update-wko-wdt-wit/weblogic-azure-aks/src/main/resources/weblogic_tooling_family.json"
 
 export optUninstallMaxTry=5 # Max attempts to wait for the operator uninstalled
 export optUninstallInterval=10
 
 export wlsContainerName="weblogic-server"
-export wdtDownloadURL="https://github.com/oracle/weblogic-deploy-tooling/releases/download/release-1.9.17/weblogic-deploy.zip"
-export witDownloadURL="https://github.com/oracle/weblogic-image-tool/releases/download/release-1.9.16/imagetool.zip"
 export wlsPostgresqlDriverUrl="https://jdbc.postgresql.org/download/postgresql-42.3.6.jar"
 export wlsMSSQLDriverUrl="https://repo.maven.apache.org/maven2/com/microsoft/sqlserver/mssql-jdbc/10.2.1.jre8/mssql-jdbc-10.2.1.jre8.jar"

--- a/weblogic-azure-aks/src/main/arm/scripts/genImageModel.sh
+++ b/weblogic-azure-aks/src/main/arm/scripts/genImageModel.sh
@@ -33,7 +33,7 @@ domainInfo:
   AdminUserName: "@@SECRET:__weblogic-credentials__:username@@"
   AdminPassword: "@@SECRET:__weblogic-credentials__:password@@"
   ServerStartMode: "prod"
-  domainLibraries: [ 'wlsdeploy/domainLibraries/postgresql-42.2.8.jar', 'wlsdeploy/domainLibraries/mssql-jdbc-7.4.1.jre8.jar'${dbDriverPaths}]
+  domainLibraries: [ 'wlsdeploy/domainLibraries/${constPostgreDriverName}', 'wlsdeploy/domainLibraries/${constMSSQLDriverName}'${dbDriverPaths}]
 
 topology:
   Name: "@@ENV:CUSTOM_DOMAIN_NAME@@"

--- a/weblogic-azure-aks/src/main/arm/scripts/setupWLSDomain.sh
+++ b/weblogic-azure-aks/src/main/arm/scripts/setupWLSDomain.sh
@@ -236,6 +236,19 @@ function validate_status() {
     fi
 }
 
+function get_wls_operator_version() {
+    local wlsToolingFamilyJsonFile=weblogic_tooling_family.json
+    # download the json file that wls operator version from weblogic-azure repo.
+    curl -m ${curlMaxTime} -fsL "${gitUrl4WLSToolingFamilyJsonFile}" -o ${wlsToolingFamilyJsonFile}
+    if [ $? -eq 0 ]; then
+        wlsOptVersion=$(cat ${wlsToolingFamilyJsonFile} | jq  ".items[] | select(.key==\"WKO\") | .version" | tr -d "\"")
+        echo "WKO version: ${optVersion}"
+    else
+        wlsOptVersion=""
+        echo "WKO version: latest"
+    fi
+}
+
 # Install latest kubectl and Helm
 function install_utilities() {
     if [ -d "apps" ]; then
@@ -798,7 +811,6 @@ export wlsOptHelmChart="https://oracle.github.io/weblogic-kubernetes-operator/ch
 export wlsOptNameSpace="weblogic-operator-ns"
 export wlsOptRelease="weblogic-operator"
 export wlsOptSA="weblogic-operator-sa"
-export wlsOptVersion="3.2.5"
 export wlsIdentityKeyStoreFileName="security/identity.keystore"
 export wlsTrustKeyStoreFileName="security/trust.keystore"
 export wlsTrustKeyStoreJKSFileName="security/trust.jks"
@@ -806,6 +818,8 @@ export wlsTrustKeyStoreJKSFileName="security/trust.jks"
 read_sensitive_parameters_from_stdin
 
 validate_input
+
+get_wls_operator_version
 
 install_utilities
 

--- a/weblogic-azure-aks/src/main/bicep/modules/_azure-resoruces/_aks.bicep
+++ b/weblogic-azure-aks/src/main/bicep/modules/_azure-resoruces/_aks.bicep
@@ -138,9 +138,7 @@ resource aksCluster 'Microsoft.ContainerService/managedClusters@2021-02-01' = if
       httpApplicationRouting: {
         enabled: false
       }
-      omsAgent: {
-        enabled: bool('${enableAzureMonitoring}')
-      }
+      omsAgent: enableAzureMonitoring ? obj_aciEnableOmsAgent : obj_aciDisableOmsAgent
     }
     enableRBAC: true
     networkProfile: {


### PR DESCRIPTION
Resolve #159 
Dependency: #162 

The WLS tooling family versions are stored in `weblogic-azure-aks/src/main/resources/weblogic_tooling_family.json`, see #162 

- WKO: 3.4.1
- WDT: 2.3.0
- WIT: 1.11.1

Note: the pr conflicts with #161, I will resolve it after #161 is merged.