### PR TITLE
'Bring your own VNET' for cluster offer

### DIFF
--- a/.github/workflows/buildWlsVm4CcArtifact.yml
+++ b/.github/workflows/buildWlsVm4CcArtifact.yml
@@ -65,7 +65,7 @@ jobs:
         uses: actions/checkout@v2
         with:
           path: ${{ env.repoName }}
-          ref: ${{ github.event.inputs.ref }}
+          ref: ${{ env.ref }}
       - name: Set up JDK 1.8
         uses: actions/setup-java@v1
         with:

--- a/.github/workflows/buildWlsVm4DcArtifact.yml
+++ b/.github/workflows/buildWlsVm4DcArtifact.yml
@@ -66,7 +66,7 @@ jobs:
         uses: actions/checkout@v2
         with:
           path: ${{ env.repoName }}
-          ref: ${{ github.event.inputs.ref }}
+          ref: ${{ env.ref }}
       - name: Set up JDK 1.8
         uses: actions/setup-java@v1
         with:

--- a/.github/workflows/buildWlsVm4SnArtifact.yml
+++ b/.github/workflows/buildWlsVm4SnArtifact.yml
@@ -67,7 +67,7 @@ jobs:
         uses: actions/checkout@v2
         with:
           path: ${{ env.repoName }}
-          ref: ${{ github.event.inputs.ref }}
+          ref: ${{ env.ref }}
       - name: Set up JDK 1.8
         uses: actions/setup-java@v1
         with:

--- a/.github/workflows/testWlsVmCluster.yml
+++ b/.github/workflows/testWlsVmCluster.yml
@@ -10,10 +10,14 @@ on:
         description: "Specify whether to enable ELK depoyment or not."
         required: true
         default: "false"
+      ref:
+        description: 'Specify Git Ref if needed.'
+        required: false
+        default: 'refs/heads/main'
   # Allows you to run this workflow using GitHub APIs
   # PERSONAL_ACCESS_TOKEN=<GITHUB_PERSONAL_ACCESS_TOKEN>
   # REPO_NAME=oracle/weblogic-azure/weblogic-azure-vm/arm-oraclelinux-wls-cluster
-  # curl --verbose -XPOST -u "mriccell:${PERSONAL_ACCESS_TOKEN}" -H "Accept: application/vnd.github.everest-preview+json" -H "Content-Type: application/json" https://api.github.com/repos/${REPO_NAME}/dispatches --data '{"event_type": "test-vm-cluster"}'
+  # curl --verbose -XPOST -u "mriccell:${PERSONAL_ACCESS_TOKEN}" -H "Accept: application/vnd.github.everest-preview+json" -H "Content-Type: application/json" https://api.github.com/repos/${REPO_NAME}/dispatches --data '{"event_type": "test-vm-cluster", "client_payload": {"enableELK": "false", "ref": "refs/heads/main"}}'
   repository_dispatch:
     types: [test-vm-cluster,integration-test-all]
 
@@ -53,6 +57,26 @@ jobs:
   preflight:
     runs-on: ubuntu-latest
     steps:
+      - name: Setup environment variables
+        id: setup-env-variables-based-on-dispatch-event
+        run: |
+          if [ ${{ github.event_name }} == 'workflow_dispatch' ]; then
+            enableELK=${{ github.event.inputs.enableELK }}
+            ref=${{ github.event.inputs.ref }}
+          else
+            enableELK=${{ github.event.client_payload.enableELK }}
+            ref=${{ github.event.client_payload.ref }}
+          fi
+          if [ -z "$enableELK" ]; then
+            enableELK='false'
+          fi
+          if [ -z "$ref" ]; then
+            ref='refs/heads/main'
+          fi
+          echo "##[set-output name=enableELK;]${enableELK}"
+          echo "##[set-output name=ref;]${ref}"
+          echo "enableELK=${enableELK}" >> $GITHUB_ENV
+          echo "ref=${ref}" >> $GITHUB_ENV
       - name: Checkout azure-javaee-iaas
         uses: actions/checkout@v2
         with:
@@ -70,6 +94,7 @@ jobs:
         with:
           repository: ${{env.repoOwner}}/${{env.repoName}}
           path: ${{env.repoName}}
+          ref: ${{ env.ref }}
       - name: Set up JDK 1.8
         uses: actions/setup-java@v1
         with:
@@ -77,8 +102,8 @@ jobs:
       - name: Build azure-javaee-iaas
         run: mvn -DskipTests clean install --file azure-javaee-iaas/pom.xml
       - name: Build and test ${{ env.offerName }}
-        run: mvn -Ptemplate-validation-tests clean install --file ${offerPath}/pom.xml
-
+        run: |
+          mvn -Ptemplate-validation-tests clean install --file ${offerPath}/pom.xml -Dgit.repo.owner=${{ env.repoOwner }} -Dgit.tag=${{ env.ref }}
       - name: Checkout ${{env.repoOwner}}/${{env.repoName}}
         uses: actions/checkout@v2
         with:
@@ -506,6 +531,17 @@ jobs:
             ${{ env.wlsDomainName }} \
             ${{ env.managedServerPrefix }}"
             echo "Deploy Application Gateway Template..."
+            
+            # Create subnet for application gateway
+            az network vnet subnet create \
+            --verbose \
+            --debug \
+            --resource-group ${resourceGroup} \
+            --vnet-name wls-vnet \
+            --name appgateway-subnet \
+            --address-prefixes "10.0.1.0/24"
+
+            # Create application gateway
             az group deployment create \
             --verbose \
             --debug \
@@ -626,7 +662,7 @@ jobs:
 
       - name: Set up ELK by deploying sub template
         id: enable-elk
-        if: ${{github.event_name == 'workflow_dispatch' && github.event.inputs.enableELK == 'true'}}
+        if: ${{ env.enableELK == 'true' }}
         run: |
             # Generate parameters for ELK template deployment
             bash ${{ env.offerPath }}/test/scripts/gen-parameters-deploy-elk.sh \
@@ -853,7 +889,7 @@ jobs:
             az group delete --yes --no-wait --verbose --name $resourceGroup
       - name: Delete ELK index
         id: delete-elk-index
-        if: ${{github.event_name == 'workflow_dispatch' && github.event.inputs.enableELK == 'true'}}
+        if: ${{ env.enableELK == 'true' }}
         run: |
           curl -XDELETE --user ${{ env.elkUser }}:${{ env.elkPassword }}  ${{ env.elkURI }}/azure-weblogic-cluster-${{ github.run_id }}${{ github.run_number }}
 

--- a/weblogic-azure-vm/arm-oraclelinux-wls-cluster/addnode-coherence/pom.xml
+++ b/weblogic-azure-vm/arm-oraclelinux-wls-cluster/addnode-coherence/pom.xml
@@ -12,7 +12,7 @@
 
     <groupId>com.oracle.weblogic.azure</groupId>
     <artifactId>arm-oraclelinux-wls-cluster-addnode-coherence</artifactId>
-    <version>1.0.0</version>
+    <version>1.0.1</version>
     
     <parent>
         <groupId>com.microsoft.azure.iaas</groupId>

--- a/weblogic-azure-vm/arm-oraclelinux-wls-cluster/addnode-coherence/src/main/arm/mainTemplate.json
+++ b/weblogic-azure-vm/arm-oraclelinux-wls-cluster/addnode-coherence/src/main/arm/mainTemplate.json
@@ -147,6 +147,27 @@
                 "description": "Select appropriate VM Size for Coherence"
             }
         },
+        "virtualNetworkName": {
+            "type": "string",
+            "defaultValue": "wls-vnet",
+            "metadata": {
+                "description": "Name of the existing or new VNET"
+            }
+        },
+        "virtualNetworkResourceGroupName": {
+            "type": "string",
+            "defaultValue": "[resourceGroup().name]",
+            "metadata": {
+                "description": "Resource group of Virtual network"
+            }
+        },
+        "subnetName": {
+            "type": "string",
+            "defaultValue": "wls-subnet",
+            "metadata": {
+                "description": "Name of the existing or new Subnet"
+            }
+        },
         "wlsDomainName": {
             "type": "string",
             "defaultValue": "wlsd",
@@ -227,11 +248,11 @@
         "name_scriptCoherenceFile": "setupCoherence.sh",
         "name_scriptELKConfiguration": "elkIntegration.sh",
         "name_share": "wlsshare",
-        "name_subnet": "Subnet",
-        "name_virtualNetwork": "[concat(parameters('wlsDomainName'),'_VNET')]",
+        "name_subnet": "[parameters('subnetName')]",
+        "name_virtualNetwork": "[parameters('virtualNetworkName')]",
         "name_vmMachine": "[concat(parameters('managedServerPrefix'),'StorageVM')]",
         "name_wlsServerPrefix": "[concat(parameters('managedServerPrefix'),'Storage')]",
-        "ref_subnet": "[resourceId('Microsoft.Network/virtualNetworks/subnets', variables('name_virtualNetwork'), variables('name_subnet'))]",
+        "ref_subnet": "[resourceId(parameters('virtualNetworkResourceGroupName'), 'Microsoft.Network/virtualNetworks/subnets', variables('name_virtualNetwork'), variables('name_subnet'))]",
         "name_customHostnameGeneratorscriptFile": "generateCustomHostNameVerifier.sh",
         "name_customHostnameVerifierJavaFile": "src/main/java/WebLogicCustomHostNameVerifier.java",
         "name_customHostnameValuesTemplate": "src/main/java/HostNameValuesTemplate.txt",

--- a/weblogic-azure-vm/arm-oraclelinux-wls-cluster/addnode/pom.xml
+++ b/weblogic-azure-vm/arm-oraclelinux-wls-cluster/addnode/pom.xml
@@ -12,7 +12,7 @@
 
     <groupId>com.oracle.weblogic.azure</groupId>
     <artifactId>arm-oraclelinux-wls-cluster-addnode</artifactId>
-    <version>1.0.25</version>
+    <version>1.0.26</version>
     
     <parent>
         <groupId>com.microsoft.azure.iaas</groupId>

--- a/weblogic-azure-vm/arm-oraclelinux-wls-cluster/addnode/src/main/arm/mainTemplate.json
+++ b/weblogic-azure-vm/arm-oraclelinux-wls-cluster/addnode/src/main/arm/mainTemplate.json
@@ -177,6 +177,27 @@
             "description": "Select appropriate VM Size as per requirement"
          }
       },
+      "virtualNetworkName": {
+         "type": "string",
+         "defaultValue": "wls-vnet",
+         "metadata": {
+               "description": "Name of the existing or new VNET"
+         }
+      },
+      "virtualNetworkResourceGroupName": {
+         "type": "string",
+         "defaultValue": "[resourceGroup().name]",
+         "metadata": {
+               "description": "Resource group of Virtual network"
+         }
+      },
+      "subnetName": {
+         "type": "string",
+         "defaultValue": "wls-subnet",
+         "metadata": {
+               "description": "Name of the existing or new Subnet"
+         }
+      },
       "wlsDomainName": {
          "type": "string",
          "defaultValue": "wlsd",
@@ -271,8 +292,8 @@
       "name_scriptELKConfiguration": "elkIntegration.sh",
       "name_scriptFile": "addnode.sh",
       "name_share": "wlsshare",
-      "name_subnet": "Subnet",
-      "name_virtualNetwork": "[concat(parameters('wlsDomainName'),'_VNET')]",
+      "name_subnet": "[parameters('subnetName')]",
+      "name_virtualNetwork": "[parameters('virtualNetworkName')]",
       "name_vmMachine": "[concat(parameters('managedServerPrefix'),'VM')]",
       "ref_backendAddressPool": "[resourceId('Microsoft.Network/applicationGateways/backendAddressPools', variables('name_appGateway'),variables('name_backendAddressPool'))]",
       "ref_backendHttpSettings": "[resourceId('Microsoft.Network/applicationGateways/backendHttpSettingsCollection', variables('name_appGateway'),variables('name_httpSetting'))]",
@@ -283,7 +304,7 @@
       "ref_httpListener": "[resourceId('Microsoft.Network/applicationGateways/httpListeners', variables('name_appGateway'),variables('name_httpListener'))]",
       "ref_httpsListener": "[resourceId('Microsoft.Network/applicationGateways/httpListeners', variables('name_appGateway'),variables('name_httpsListener'))]",
       "ref_sslCertificate": "[resourceId('Microsoft.Network/applicationGateways/sslCertificates', variables('name_appGateway'),variables('name_appGatewayCertificate'))]",
-      "ref_subnet": "[resourceId('Microsoft.Network/virtualNetworks/subnets', variables('name_virtualNetwork'), variables('name_subnet'))]",
+      "ref_subnet": "[resourceId(parameters('virtualNetworkResourceGroupName'), 'Microsoft.Network/virtualNetworks/subnets', variables('name_virtualNetwork'), variables('name_subnet'))]",
       "name_customHostnameGeneratorscriptFile": "generateCustomHostNameVerifier.sh",
       "name_customHostnameVerifierJavaFile": "src/main/java/WebLogicCustomHostNameVerifier.java",
       "name_customHostnameValuesTemplate": "src/main/java/HostNameValuesTemplate.txt",

--- a/weblogic-azure-vm/arm-oraclelinux-wls-cluster/arm-oraclelinux-wls-cluster/pom.xml
+++ b/weblogic-azure-vm/arm-oraclelinux-wls-cluster/arm-oraclelinux-wls-cluster/pom.xml
@@ -12,7 +12,7 @@
 
     <groupId>com.oracle.weblogic.azure</groupId>
     <artifactId>arm-oraclelinux-wls-cluster</artifactId>
-    <version>1.0.43000</version>
+    <version>1.0.44000</version>
     
     <parent>
         <groupId>com.microsoft.azure.iaas</groupId>

--- a/weblogic-azure-vm/arm-oraclelinux-wls-cluster/arm-oraclelinux-wls-cluster/src/main/arm/createUiDefinition.json
+++ b/weblogic-azure-vm/arm-oraclelinux-wls-cluster/arm-oraclelinux-wls-cluster/src/main/arm/createUiDefinition.json
@@ -190,19 +190,6 @@
                         }
                     },
                     {
-                        "name": "dnsLabelPrefix",
-                        "type": "Microsoft.Common.TextBox",
-                        "label": "DNS Label Prefix",
-                        "toolTip": "The string to prepend to the DNS label.",
-                        "defaultValue": "wls",
-                        "constraints": {
-                            "required": true,
-                            "regex": "^[a-z0-9A-Z]{3,10}$",
-                            "validationMessage": "The prefix must be between 3 and 10 characters long and contain letters, numbers only."
-                        },
-                        "visible": "[bool(basics('basicsOptional').basicsOptionalAcceptDefaults)]"
-                    },
-                    {
                         "name": "managedServerPrefix",
                         "type": "Microsoft.Common.TextBox",
                         "label": "Managed Server Prefix",
@@ -225,40 +212,6 @@
                             "required": true,
                             "regex": "^[a-z0-9A-Z]{3,20}$",
                             "validationMessage": "The Domain Name must be between 3 and 20 characters long and contain letters, numbers only."
-                        },
-                        "visible": "[bool(basics('basicsOptional').basicsOptionalAcceptDefaults)]"
-                    },
-                    {
-                        "name": "portsToExpose",
-                        "label": "Ports and port ranges to expose (N or N-N, comma separated)",
-                        "type": "Microsoft.Common.TextBox",
-                        "toolTip": "Ports and port ranges to expose (N or N-N, comma separated)",
-                        "defaultValue": "80,443,7001-9000",
-                        "constraints": {
-                            "required": true,
-                            "regex": "^((([0-9]+-[0-9]+)|([0-9]+))[,]?)+[^,]$",
-                            "validationMessage": "Only numbers, hyphen separated ranges of numbers, separated by commas"
-                        },
-                        "visible": "[bool(basics('basicsOptional').basicsOptionalAcceptDefaults)]"
-                    },
-                    {
-                        "name": "denyPublicTrafficForAdminServer",
-                        "type": "Microsoft.Common.OptionsGroup",
-                        "label": "Deny public traffic for admin server?",
-                        "defaultValue": "No",
-                        "toolTip": "Select 'Yes' to deny public traffic for admin server. Configuration here for port 7001 and 7002 has a higher priority than above.",
-                        "constraints": {
-                            "allowedValues": [
-                                {
-                                    "label": "No",
-                                    "value": false
-                                },
-                                {
-                                    "label": "Yes",
-                                    "value": true
-                                }
-                            ],
-                            "required": true
                         },
                         "visible": "[bool(basics('basicsOptional').basicsOptionalAcceptDefaults)]"
                     },
@@ -992,6 +945,134 @@
                             "hideUserAssignedIdentity": false
                         },
                         "visible": "[equals(steps('section_appGateway').certificateOption, 'generateCert')]"
+                    }
+                ],
+                "visible": true
+            },
+            {
+                "name": "section_networkingConfiguration",
+                "type": "Microsoft.Common.Section",
+                "label": "Networking",
+                "elements": [
+                    {
+                        "name": "infoGatewaySubnet",
+                        "type": "Microsoft.Common.InfoBox",
+                        "visible": "[steps('section_appGateway').enableAppGateway]",
+                        "options": {
+                            "icon": "Warning",
+                            "text": "Please make sure you are using a dedicated subnet for Application Gateway.",
+                            "uri": "https://docs.microsoft.com/en-us/azure/application-gateway/configuration-infrastructure"
+                        }
+                    },
+                    {
+                        "name": "vnetInfo",
+                        "type": "Microsoft.Common.InfoBox",
+                        "visible": "[steps('section_appGateway').enableAppGateway]",
+                        "options": {
+                            "icon": "Info",
+                            "text": "When creating a new virtual network, the subnet's address prefix is calculated automatically based on the virtual network's address prefix. When using an existing virtual network, a minimum virtual network size of /24 and a minimum subnet size of /24 are required. Additionally, the subnet must be dedicated only for use by the Application Gateway."
+                        }
+                    },
+                    {
+                        "name": "virtualNetworkWithAppGateway",
+                        "type": "Microsoft.Network.VirtualNetworkCombo",
+                        "visible": "[steps('section_appGateway').enableAppGateway]",
+                        "label": {
+                            "virtualNetwork": "Virtual network",
+                            "subnets": "Subnets"
+                        },
+                        "toolTip": {
+                            "virtualNetwork": "Name of the virtual network",
+                            "subnets": "Subnets for the virtual network"
+                        },
+                        "defaultValue": {
+                            "name": "wls-vnet",
+                            "addressPrefixSize": "/23"
+                        },
+                        "constraints": {
+                            "minAddressPrefixSize": "/23"
+                        },
+                        "subnets": {
+                            "subnet1": {
+                                "label": "Subnet for WebLogic",
+                                "defaultValue": {
+                                    "name": "wls-subnet",
+                                    "addressPrefixSize": "/28"
+                                },
+                                "constraints": {
+                                    "minAddressPrefixSize": "/29",
+                                    "minAddressCount": "[add(int(basics('basicsRequired').numberOfInstances), 1)]",
+                                    "requireContiguousAddresses": false
+                                }
+                            },
+                            "subnet2": {
+                                "label": "Subnet for Application Gateway",
+                                "defaultValue": {
+                                    "name": "appgateway-subnet",
+                                    "addressPrefixSize": "/24"
+                                },
+                                "constraints": {
+                                    "minAddressPrefixSize": "/24",
+                                    "minAddressCount": 250,
+                                    "requireContiguousAddresses": false
+                                }
+                            }
+                        }
+                    },
+                    {
+                        "name": "virtualNetworkWithoutAppGateway",
+                        "type": "Microsoft.Network.VirtualNetworkCombo",
+                        "visible": "[not(steps('section_appGateway').enableAppGateway)]",
+                        "label": {
+                            "virtualNetwork": "Virtual network",
+                            "subnets": "Subnets"
+                        },
+                        "toolTip": {
+                            "virtualNetwork": "Name of the virtual network",
+                            "subnets": "Subnets for the virtual network"
+                        },
+                        "defaultValue": {
+                            "name": "wls-vnet",
+                            "addressPrefixSize": "/28"
+                        },
+                        "constraints": {
+                            "minAddressPrefixSize": "/28"
+                        },
+                        "subnets": {
+                            "subnet1": {
+                                "label": "Subnet for WebLogic",
+                                "defaultValue": {
+                                    "name": "wls-subnet",
+                                    "addressPrefixSize": "/28"
+                                },
+                                "constraints": {
+                                    "minAddressPrefixSize": "/29",
+                                    "minAddressCount": "[add(int(basics('basicsRequired').numberOfInstances), 1)]",
+                                    "requireContiguousAddresses": false
+                                }
+                            }
+                        }
+                    },
+                    {
+                        "name": "denyPublicTrafficForAdminServer",
+                        "type": "Microsoft.Common.OptionsGroup",
+                        "label": "Deny public traffic for admin server?",
+                        "defaultValue": "No",
+                        "toolTip": "Select 'Yes' to deny public traffic for admin server. Configuration here for port 7001 and 7002 has a higher priority than above.",
+                        "visible": "[or(equals(steps('section_networkingConfiguration').virtualNetworkWithAppGateway.newOrExisting, 'new'), equals(steps('section_networkingConfiguration').virtualNetworkWithoutAppGateway.newOrExisting, 'new'))]",
+                        "constraints": {
+                            "allowedValues": [
+                                {
+                                    "label": "No",
+                                    "value": false
+                                },
+                                {
+                                    "label": "Yes",
+                                    "value": true
+                                }
+                            ],
+                            "required": true
+                        }
                     },
                     {
                         "name": "denyPublicTrafficForManagedServer",
@@ -1012,20 +1093,12 @@
                             ],
                             "required": true
                         },
-                        "visible": "[steps('section_appGateway').enableAppGateway]"
-                    }
-                ],
-                "visible": true
-            },
-            {
-                "name": "section_dnsConfiguration",
-                "type": "Microsoft.Common.Section",
-                "label": "DNS Configuration",
-                "elements": [
+                        "visible": "[and(steps('section_appGateway').enableAppGateway, or(equals(steps('section_networkingConfiguration').virtualNetworkWithAppGateway.newOrExisting, 'new'), equals(steps('section_networkingConfiguration').virtualNetworkWithoutAppGateway.newOrExisting, 'new')))]"
+                    },
                     {
                         "name": "dnsConfigurationText",
                         "type": "Microsoft.Common.TextBlock",
-                        "visible": true,
+                        "visible": "[or(equals(steps('section_networkingConfiguration').virtualNetworkWithAppGateway.newOrExisting, 'new'), equals(steps('section_networkingConfiguration').virtualNetworkWithoutAppGateway.newOrExisting, 'new'))]",
                         "options": {
                             "text": "Selecting 'Yes' here will cause the template to provision Oracle WebLogic Server Administration Console and Application Gateway using a custom DNS Name (for example: applications.contoso.com)",
                             "link": {
@@ -1037,7 +1110,7 @@
                     {
                         "name": "enableCustomDNS",
                         "type": "Microsoft.Common.OptionsGroup",
-                        "visible": true,
+                        "visible": "[or(equals(steps('section_networkingConfiguration').virtualNetworkWithAppGateway.newOrExisting, 'new'), equals(steps('section_networkingConfiguration').virtualNetworkWithoutAppGateway.newOrExisting, 'new'))]",
                         "label": "Configure Custom DNS Alias?",
                         "defaultValue": "No",
                         "toolTip": "Select 'Yes' to configure Custom DNS Alias.",
@@ -1056,10 +1129,36 @@
                         }
                     },
                     {
+                        "name": "dnsLabelPrefix",
+                        "type": "Microsoft.Common.TextBox",
+                        "label": "DNS Label Prefix",
+                        "toolTip": "The string to prepend to the DNS label.",
+                        "defaultValue": "wls",
+                        "constraints": {
+                            "required": true,
+                            "regex": "^[a-z0-9A-Z]{3,10}$",
+                            "validationMessage": "The prefix must be between 3 and 10 characters long and contain letters, numbers only."
+                        },
+                        "visible": "[bool(steps('section_networkingConfiguration').enableCustomDNS)]"
+                    },
+                    {
+                        "name": "portsToExpose",
+                        "label": "Ports and port ranges to expose (N or N-N, comma separated)",
+                        "type": "Microsoft.Common.TextBox",
+                        "toolTip": "Ports and port ranges to expose (N or N-N, comma separated)",
+                        "defaultValue": "80,443,7001-9000",
+                        "constraints": {
+                            "required": true,
+                            "regex": "^((([0-9]+-[0-9]+)|([0-9]+))[,]?)+[^,]$",
+                            "validationMessage": "Only numbers, hyphen separated ranges of numbers, separated by commas"
+                        },
+                        "visible": "[bool(steps('section_networkingConfiguration').enableCustomDNS)]"
+                    },
+                    {
                         "name": "customDNSSettings",
                         "type": "Microsoft.Common.Section",
                         "label": "DNS Configuration Settings",
-                        "visible": "[bool(steps('section_dnsConfiguration').enableCustomDNS)]",
+                        "visible": "[bool(steps('section_networkingConfiguration').enableCustomDNS)]",
                         "elements": [
                             {
                                 "name": "bringDNSZone",
@@ -1083,7 +1182,7 @@
                             {
                                 "name": "createDNSZoneText",
                                 "type": "Microsoft.Common.InfoBox",
-                                "visible": "[not(bool(steps('section_dnsConfiguration').customDNSSettings.bringDNSZone))]",
+                                "visible": "[not(bool(steps('section_networkingConfiguration').customDNSSettings.bringDNSZone))]",
                                 "options": {
                                     "icon": "Info",
                                     "text": "You must perform DNS Domain Delegation at your DNS Registry after deployment.",
@@ -1096,7 +1195,7 @@
                                 "options": {
                                     "text": "If you choose to use an existing Azure DNS Zone, you must select a user-assigned managed identity to enable the necessary configuration."
                                 },
-                                "visible": "[steps('section_dnsConfiguration').customDNSSettings.bringDNSZone]"
+                                "visible": "[steps('section_networkingConfiguration').customDNSSettings.bringDNSZone]"
                             },
                             {
                                 "name": "dnszoneName",
@@ -1119,9 +1218,9 @@
                                 "constraints": {
                                     "required": true,
                                     "regex": "^[a-z0-9A-Z.\\-_()]{0,89}([a-z0-9A-Z\\-_()]{1})$",
-                                    "validationMessage": "[if(greater(length(steps('section_dnsConfiguration').existingDNSZonesSettings.dnsZoneResourceGroup), 90),'Resource group names only allow up to 90 characters.', 'Resource group names only allow alphanumeric characters, periods, underscores, hyphens and parenthesis and cannot end in a period.')]"
+                                    "validationMessage": "[if(greater(length(steps('section_networkingConfiguration').existingDNSZonesSettings.dnsZoneResourceGroup), 90),'Resource group names only allow up to 90 characters.', 'Resource group names only allow alphanumeric characters, periods, underscores, hyphens and parenthesis and cannot end in a period.')]"
                                 },
-                                "visible": "[steps('section_dnsConfiguration').customDNSSettings.bringDNSZone]"
+                                "visible": "[steps('section_networkingConfiguration').customDNSSettings.bringDNSZone]"
                             },
                             {
                                 "name": "dnszoneAdminConsoleLabel",
@@ -1137,7 +1236,7 @@
                                             "message": "Each label must contain between 1 and 63 characters. Each label must only contain letters, numbers, underscores, and dashes."
                                         },
                                         {
-                                            "isValid": "[less(sub(length(concat(steps('section_dnsConfiguration').customDNSSettings.dnszoneAdminConsoleLabel,'.',steps('section_dnsConfiguration').customDNSSettings.dnszoneName)),length(replace(concat(steps('section_dnsConfiguration').customDNSSettings.dnszoneAdminConsoleLabel,'.',steps('section_dnsConfiguration').customDNSSettings.dnszoneName), '.', ''))),34)]",
+                                            "isValid": "[less(sub(length(concat(steps('section_networkingConfiguration').customDNSSettings.dnszoneAdminConsoleLabel,'.',steps('section_networkingConfiguration').customDNSSettings.dnszoneName)),length(replace(concat(steps('section_networkingConfiguration').customDNSSettings.dnszoneAdminConsoleLabel,'.',steps('section_networkingConfiguration').customDNSSettings.dnszoneName), '.', ''))),34)]",
                                             "message": "Subdomain must be between 2 and 34 labels. For example, \"admin.contoso.com\" has 3 labels."
                                         }
                                     ]
@@ -1157,12 +1256,12 @@
                                             "message": "Each label must contain between 1 and 63 characters. Each label must only contain letters, numbers, underscores, and dashes."
                                         },
                                         {
-                                            "isValid": "[less(sub(length(concat(if(empty(steps('section_dnsConfiguration').customDNSSettings.dnszoneGatewayLabel), '', steps('section_dnsConfiguration').customDNSSettings.dnszoneGatewayLabel),'.',steps('section_dnsConfiguration').customDNSSettings.dnszoneName)),length(replace(concat(if(empty(steps('section_dnsConfiguration').customDNSSettings.dnszoneGatewayLabel), '', steps('section_dnsConfiguration').customDNSSettings.dnszoneGatewayLabel),'.',steps('section_dnsConfiguration').customDNSSettings.dnszoneName), '.', ''))),34)]",
+                                            "isValid": "[less(sub(length(concat(if(empty(steps('section_networkingConfiguration').customDNSSettings.dnszoneGatewayLabel), '', steps('section_networkingConfiguration').customDNSSettings.dnszoneGatewayLabel),'.',steps('section_networkingConfiguration').customDNSSettings.dnszoneName)),length(replace(concat(if(empty(steps('section_networkingConfiguration').customDNSSettings.dnszoneGatewayLabel), '', steps('section_networkingConfiguration').customDNSSettings.dnszoneGatewayLabel),'.',steps('section_networkingConfiguration').customDNSSettings.dnszoneName), '.', ''))),34)]",
                                             "message": "Subdomain must be between 2 and 34 labels. For example, \"applications.contoso.com\" has 3 labels."
                                         }
                                     ]
                                 },
-                                "visible": "[and(bool(steps('section_appGateway').enableAppGateway), bool(steps('section_dnsConfiguration').enableCustomDNS))]"
+                                "visible": "[and(bool(steps('section_appGateway').enableAppGateway), bool(steps('section_networkingConfiguration').enableCustomDNS))]"
                             },
                             {
                                 "name": "reuseIdentity",
@@ -1182,12 +1281,12 @@
                                         }
                                     ]
                                 },
-                                "visible": "[and(greater(length(steps('section_appGateway').gatewayIdentity.userAssignedIdentities),0), bool(steps('section_dnsConfiguration').customDNSSettings.bringDNSZone))]"
+                                "visible": "[and(greater(length(steps('section_appGateway').gatewayIdentity.userAssignedIdentities),0), bool(steps('section_networkingConfiguration').customDNSSettings.bringDNSZone))]"
                             },
                             {
                                 "name": "infoDNSIndentity",
                                 "type": "Microsoft.Common.InfoBox",
-                                "visible": "[and(bool(steps('section_dnsConfiguration').customDNSSettings.bringDNSZone), less(length(steps('section_appGateway').gatewayIdentity.userAssignedIdentities),1), less(length(steps('section_dnsConfiguration').customDNSSettings.dnsIdentity.userAssignedIdentities), 1))]",
+                                "visible": "[and(bool(steps('section_networkingConfiguration').customDNSSettings.bringDNSZone), less(length(steps('section_appGateway').gatewayIdentity.userAssignedIdentities),1), less(length(steps('section_networkingConfiguration').customDNSSettings.dnsIdentity.userAssignedIdentities), 1))]",
                                 "options": {
                                     "icon": "Error",
                                     "text": "This option will use Azure deployment scripts to update records to your Azure DNS Zone. You have to add at least one user-assigned identity to access Azure resources.",
@@ -1208,7 +1307,7 @@
                                     "hideSystemAssignedIdentity": true,
                                     "hideUserAssignedIdentity": false
                                 },
-                                "visible": "[if(greater(length(steps('section_appGateway').gatewayIdentity.userAssignedIdentities),0),and(equals(steps('section_dnsConfiguration').customDNSSettings.reuseIdentity, false), bool(steps('section_dnsConfiguration').customDNSSettings.bringDNSZone)), bool(steps('section_dnsConfiguration').customDNSSettings.bringDNSZone))]"
+                                "visible": "[if(greater(length(steps('section_appGateway').gatewayIdentity.userAssignedIdentities),0),and(equals(steps('section_networkingConfiguration').customDNSSettings.reuseIdentity, false), bool(steps('section_networkingConfiguration').customDNSSettings.bringDNSZone)), bool(steps('section_networkingConfiguration').customDNSSettings.bringDNSZone))]"
                             }
                         ]
                     }
@@ -1820,6 +1919,7 @@
             "aadsServerHost": "[steps('section_aad').aadInfo.aadsServerHost]",
             "adminPasswordOrKey": "[if(equals(basics('basicsRequired').adminPasswordOrKey.authenticationType, 'password'), basics('basicsRequired').adminPasswordOrKey.password, basics('basicsRequired').adminPasswordOrKey.sshPublicKey)]",
             "adminUsername": "[basics('basicsRequired').adminUsername]",
+			"addressPrefixes": "[if(steps('section_appGateway').enableAppGateway, steps('section_networkingConfiguration').virtualNetworkWithAppGateway.addressPrefixes, steps('section_networkingConfiguration').virtualNetworkWithoutAppGateway.addressPrefixes)]",
             "appGatewayCertificateOption": "[steps('section_appGateway').certificateOption]",
             "appGatewayIdentity": "[steps('section_appGateway').gatewayIdentity]",
             "appGatewaySSLCertData": "[steps('section_appGateway').keyVaultSSLCertData]",
@@ -1827,14 +1927,14 @@
             "authenticationType": "[basics('basicsRequired').adminPasswordOrKey.authenticationType]",
             "enableDB": "[bool(steps('section_database').enableDB)]",
             "databaseType": "[steps('section_database').databaseConnectionInfo.databaseType]",
-            "denyPublicTrafficForAdminServer": "[basics('basicsOptional').denyPublicTrafficForAdminServer]",
-            "denyPublicTrafficForManagedServer": "[steps('section_appGateway').denyPublicTrafficForManagedServer]",
-            "dnsLabelPrefix": "[basics('basicsOptional').dnsLabelPrefix]",
-            "dnszoneIdentity": "[if(greater(length(steps('section_dnsConfiguration').customDNSSettings.dnsIdentity.userAssignedIdentities),0),steps('section_dnsConfiguration').customDNSSettings.dnsIdentity, steps('section_appGateway').gatewayIdentity)]",
-            "dnszoneName": "[steps('section_dnsConfiguration').customDNSSettings.dnszoneName]",
-            "dnszoneResourceGroup": "[steps('section_dnsConfiguration').customDNSSettings.dnsZoneResourceGroup]",
-            "dnszoneAdminConsoleLabel": "[steps('section_dnsConfiguration').customDNSSettings.dnszoneAdminConsoleLabel]",
-            "dnszoneAppGatewayLabel": "[steps('section_dnsConfiguration').customDNSSettings.dnszoneGatewayLabel]",
+            "denyPublicTrafficForAdminServer": "[steps('section_networkingConfiguration').denyPublicTrafficForAdminServer]",
+            "denyPublicTrafficForManagedServer": "[steps('section_networkingConfiguration').denyPublicTrafficForManagedServer]",
+            "dnsLabelPrefix": "[steps('section_networkingConfiguration').dnsLabelPrefix]",
+            "dnszoneIdentity": "[if(greater(length(steps('section_networkingConfiguration').customDNSSettings.dnsIdentity.userAssignedIdentities),0),steps('section_networkingConfiguration').customDNSSettings.dnsIdentity, steps('section_appGateway').gatewayIdentity)]",
+            "dnszoneName": "[steps('section_networkingConfiguration').customDNSSettings.dnszoneName]",
+            "dnszoneResourceGroup": "[steps('section_networkingConfiguration').customDNSSettings.dnsZoneResourceGroup]",
+            "dnszoneAdminConsoleLabel": "[steps('section_networkingConfiguration').customDNSSettings.dnszoneAdminConsoleLabel]",
+            "dnszoneAppGatewayLabel": "[steps('section_networkingConfiguration').customDNSSettings.dnszoneGatewayLabel]",
             "dsConnectionURL": "[steps('section_database').databaseConnectionInfo.dsConnectionURL]",
             "dbGlobalTranPro": "[steps('section_database').databaseConnectionInfo.dbGlobalTranPro]",
             "dbPassword": "[steps('section_database').databaseConnectionInfo.dbPassword]",
@@ -1846,9 +1946,9 @@
             "enableAppGateway": "[steps('section_appGateway').enableAppGateway]",
             "enableCoherence": "[bool(steps('section_coherence').enableCoherence)]",
             "enableCoherenceWebLocalStorage": "[bool(if(bool(steps('section_coherence').enableCoherence),steps('section_coherence').coherenceInfo.enableCoherenceWebLocalStorage,'false'))]",
-            "enableDNSConfiguration": "[bool(steps('section_dnsConfiguration').enableCustomDNS)]",
+            "enableDNSConfiguration": "[bool(steps('section_networkingConfiguration').enableCustomDNS)]",
             "enableELK": "[bool(steps('section_elk').enableELK)]",
-            "hasDNSZones": "[bool(if(bool(steps('section_dnsConfiguration').enableCustomDNS), steps('section_dnsConfiguration').customDNSSettings.bringDNSZone, 'false'))]",
+            "hasDNSZones": "[bool(if(bool(steps('section_networkingConfiguration').enableCustomDNS), steps('section_networkingConfiguration').customDNSSettings.bringDNSZone, 'false'))]",
             "jdbcDataSourceName": "[steps('section_database').databaseConnectionInfo.jdbcDataSourceName]",
             "logsToIntegrate": "[steps('section_elk').elkInfo.logsToIntegrate]",
             "keyVaultName": "[steps('section_appGateway').keyVaultName]",
@@ -1858,7 +1958,7 @@
             "managedServerPrefix": "[basics('basicsOptional').managedServerPrefix]",
             "numberOfCoherenceCacheInstances": "[int(if(bool(steps('section_coherence').enableCoherence),steps('section_coherence').coherenceInfo.numberOfCoherenceCacheInstances,'1'))]",
             "numberOfInstances": "[int(basics('basicsRequired').numberOfInstances)]",
-            "portsToExpose": "[basics('basicsOptional').portsToExpose]",
+            "portsToExpose": "[steps('section_networkingConfiguration').portsToExpose]",
             "skuUrnVersion": "[basics('skuUrnVersion')]",
             "useSystemAssignedManagedIdentity": "[basics('basicsOptional').useSystemAssignedManagedIdentity]",
             "vmSizeSelect": "[basics('vmSizeSelect')]",
@@ -1875,6 +1975,10 @@
             "enableHTTPAdminListenPort": "[basics('basicsOptional').enableAdminHTTPListenPort]",
             "enableCustomSSL":"[steps('section_sslConfiguration').enableCustomSSL]",
             "sslConfigurationAccessOption": "[steps('section_sslConfiguration').sslConfigurationAccessOption]",
+			"subnetName": "[if(steps('section_appGateway').enableAppGateway, steps('section_networkingConfiguration').virtualNetworkWithAppGateway.subnets.subnet1.name, steps('section_networkingConfiguration').virtualNetworkWithoutAppGateway.subnets.subnet1.name)]",
+            "subnetPrefix": "[if(steps('section_appGateway').enableAppGateway, steps('section_networkingConfiguration').virtualNetworkWithAppGateway.subnets.subnet1.addressPrefix, steps('section_networkingConfiguration').virtualNetworkWithoutAppGateway.subnets.subnet1.addressPrefix)]",
+            "subnetForAppGateway": "[steps('section_networkingConfiguration').virtualNetworkWithAppGateway.subnets.subnet2.name]",
+            "subnetPrefixForAppGateway": "[steps('section_networkingConfiguration').virtualNetworkWithAppGateway.subnets.subnet2.addressPrefix]",
             "adminSSLKeyVaultResourceGroup": "[steps('section_sslConfiguration').keyVaultStoredCustomSSLSettings.adminSSLKeyVaultResourceGroup]",
             "adminSSLKeyVaultName": "[steps('section_sslConfiguration').keyVaultStoredCustomSSLSettings.adminSSLKeyVaultName]",
             "keyVaultCustomIdentityKeyStoreDataSecretName": "[steps('section_sslConfiguration').keyVaultStoredCustomSSLSettings.keyVaultCustomIdentityKeyStoreDataSecretName]",
@@ -1892,7 +1996,10 @@
             "uploadedCustomTrustKeyStorePassPhrase": "[steps('section_sslConfiguration').uploadedCustomSSLSettings.uploadedCustomTrustKeyStorePassPhrase]",
             "uploadedCustomTrustKeyStoreType": "[steps('section_sslConfiguration').uploadedCustomSSLSettings.uploadedCustomTrustKeyStoreType]",
             "uploadedPrivateKeyAlias": "[steps('section_sslConfiguration').uploadedCustomSSLSettings.uploadedPrivateKeyAlias]",
-            "uploadedPrivateKeyPassPhrase": "[steps('section_sslConfiguration').uploadedCustomSSLSettings.uploadedPrivateKeyPassPhrase]"
+            "uploadedPrivateKeyPassPhrase": "[steps('section_sslConfiguration').uploadedCustomSSLSettings.uploadedPrivateKeyPassPhrase]",
+			"virtualNetworkName": "[if(steps('section_appGateway').enableAppGateway, steps('section_networkingConfiguration').virtualNetworkWithAppGateway.name, steps('section_networkingConfiguration').virtualNetworkWithoutAppGateway.name)]",
+            "virtualNetworkResourceGroupName": "[if(steps('section_appGateway').enableAppGateway, steps('section_networkingConfiguration').virtualNetworkWithAppGateway.resourceGroup, steps('section_networkingConfiguration').virtualNetworkWithoutAppGateway.resourceGroup)]",
+            "virtualNetworkNewOrExisting": "[if(steps('section_appGateway').enableAppGateway, steps('section_networkingConfiguration').virtualNetworkWithAppGateway.newOrExisting, steps('section_networkingConfiguration').virtualNetworkWithoutAppGateway.newOrExisting)]"
         }
     }
 }

--- a/weblogic-azure-vm/arm-oraclelinux-wls-cluster/arm-oraclelinux-wls-cluster/src/main/arm/createUiDefinition.json
+++ b/weblogic-azure-vm/arm-oraclelinux-wls-cluster/arm-oraclelinux-wls-cluster/src/main/arm/createUiDefinition.json
@@ -967,10 +967,10 @@
                     {
                         "name": "vnetInfo",
                         "type": "Microsoft.Common.InfoBox",
-                        "visible": "[steps('section_appGateway').enableAppGateway]",
+                        "visible": "true",
                         "options": {
                             "icon": "Info",
-                            "text": "When creating a new virtual network, the subnet's address prefix is calculated automatically based on the virtual network's address prefix. When using an existing virtual network, a minimum virtual network size of /24 and a minimum subnet size of /24 are required. Additionally, the subnet must be dedicated only for use by the Application Gateway."
+                            "text": "When creating a new virtual network, the subnet's address prefix is calculated automatically based on the virtual network's address prefix. When using an existing virtual network, a minimum virtual network size of /24 and a minimum subnet size of /24 are required. If deploying an Application Gateway, it must be deployed in its own dedicated subnet with a minimum subnet size of /29."
                         }
                     },
                     {

--- a/weblogic-azure-vm/arm-oraclelinux-wls-cluster/arm-oraclelinux-wls-cluster/src/main/arm/mainTemplate.json
+++ b/weblogic-azure-vm/arm-oraclelinux-wls-cluster/arm-oraclelinux-wls-cluster/src/main/arm/mainTemplate.json
@@ -434,6 +434,68 @@
                 "description": "Select appropriate VM Size for Coherence"
             }
         },
+        "virtualNetworkNewOrExisting": {
+            "type": "string",
+            "defaultValue": "new",
+            "allowedValues": [
+                "new",
+                "existing"
+            ],
+            "metadata": {
+                "description": "Specify whether to create a new or existing virtual network for the VM."
+            }
+        },
+        "virtualNetworkName": {
+            "type": "string",
+            "defaultValue": "wls-vnet",
+            "metadata": {
+                "description": "Name of the existing or new VNET"
+            }
+        },
+        "virtualNetworkResourceGroupName": {
+            "type": "string",
+            "defaultValue": "[resourceGroup().name]",
+            "metadata": {
+                "description": "Resource group of Virtual network"
+            }
+        },
+        "addressPrefixes": {
+            "type": "array",
+            "defaultValue": [
+                "10.0.0.0/16"
+            ],
+            "metadata": {
+                "description": "Address prefix of the VNET."
+            }
+        },
+        "subnetName": {
+            "type": "string",
+            "defaultValue": "wls-subnet",
+            "metadata": {
+                "description": "Name of the existing or new Subnet"
+            }
+        },
+        "subnetPrefix": {
+            "type": "string",
+            "defaultValue": "10.0.0.0/24",
+            "metadata": {
+                "description": "Address prefix of the subnet"
+            }
+        },
+        "subnetForAppGateway": {
+            "type": "string",
+            "defaultValue": "appgateway-subnet",
+            "metadata": {
+                "description": "Name of the existing or new Subnet for Application Gateway"
+            }
+        },
+        "subnetPrefixForAppGateway": {
+            "type": "string",
+            "defaultValue": "10.0.1.0/24",
+            "metadata": {
+                "description": "Address prefix of the subnet for Application Gateway"
+            }
+        },
         "wlsDomainName": {
             "defaultValue": "wlsd",
             "type": "string",
@@ -715,6 +777,9 @@
                     "authenticationType": {
                         "value": "[parameters('authenticationType')]"
                     },
+                    "addressPrefixes": {
+                        "value": "[parameters('addressPrefixes')]"
+                    },
                     "dnsLabelPrefix": {
                         "value": "[parameters('dnsLabelPrefix')]"
                     },
@@ -733,6 +798,18 @@
                     "skuUrnVersion": {
                         "value": "[parameters('skuUrnVersion')]"
                     },
+                    "subnetName": {
+                        "value": "[parameters('subnetName')]"
+                    },
+                    "subnetPrefix": {
+                        "value": "[parameters('subnetPrefix')]"
+                    },
+                    "subnetForAppGateway": {
+                        "value": "[parameters('subnetForAppGateway')]"
+                    },
+                    "subnetPrefixForAppGateway": {
+                        "value": "[parameters('subnetPrefixForAppGateway')]"
+                    },
                     "usePreviewImage": {
                         "value": "[parameters('usePreviewImage')]"
                     },
@@ -742,6 +819,15 @@
                     "vmSizeSelect": {
                         "value": "[parameters('vmSizeSelect')]"
                     },
+                    "virtualNetworkNewOrExisting": {
+                        "value": "[parameters('virtualNetworkNewOrExisting')]"
+                    },
+                    "virtualNetworkName": {
+                        "value": "[parameters('virtualNetworkName')]"
+                    },
+                    "virtualNetworkResourceGroupName": {
+                        "value": "[parameters('virtualNetworkResourceGroupName')]"
+                    },
                     "wlsDomainName": {
                         "value": "[parameters('wlsDomainName')]"
                     },
@@ -750,6 +836,9 @@
                     },
                     "wlsUserName": {
                         "value": "[parameters('wlsUserName')]"
+                    },
+                    "enableAppGateway": {
+                        "value": "[parameters('enableAppGateway')]"
                     },
                     "enableHTTPAdminListenPort":{
                         "value": "[parameters('enableHTTPAdminListenPort')]"
@@ -838,6 +927,9 @@
                     "authenticationType": {
                         "value": "[parameters('authenticationType')]"
                     },
+                    "addressPrefixes": {
+                        "value": "[parameters('addressPrefixes')]"
+                    },
                     "dnsLabelPrefix": {
                         "value": "[parameters('dnsLabelPrefix')]"
                     },
@@ -856,6 +948,18 @@
                     "skuUrnVersion": {
                         "value": "[parameters('skuUrnVersion')]"
                     },
+                    "subnetName": {
+                        "value": "[parameters('subnetName')]"
+                    },
+                    "subnetPrefix": {
+                        "value": "[parameters('subnetPrefix')]"
+                    },
+                    "subnetForAppGateway": {
+                        "value": "[parameters('subnetForAppGateway')]"
+                    },
+                    "subnetPrefixForAppGateway": {
+                        "value": "[parameters('subnetPrefixForAppGateway')]"
+                    },
                     "usePreviewImage": {
                         "value": "[parameters('usePreviewImage')]"
                     },
@@ -865,6 +969,15 @@
                     "vmSizeSelect": {
                         "value": "[parameters('vmSizeSelect')]"
                     },
+                    "virtualNetworkNewOrExisting": {
+                        "value": "[parameters('virtualNetworkNewOrExisting')]"
+                    },
+                    "virtualNetworkName": {
+                        "value": "[parameters('virtualNetworkName')]"
+                    },
+                    "virtualNetworkResourceGroupName": {
+                        "value": "[parameters('virtualNetworkResourceGroupName')]"
+                    },
                     "wlsDomainName": {
                         "value": "[parameters('wlsDomainName')]"
                     },
@@ -873,6 +986,9 @@
                     },
                     "wlsUserName": {
                         "value": "[parameters('wlsUserName')]"
+                    },
+                    "enableAppGateway": {
+                        "value": "[parameters('enableAppGateway')]"
                     },
                     "enableHTTPAdminListenPort":{
                         "value": "[parameters('enableHTTPAdminListenPort')]"
@@ -998,6 +1114,7 @@
         {
             "type": "Microsoft.Resources/deployments",
             "apiVersion": "${azure.apiVersion}",
+            "condition": "[equals(parameters('virtualNetworkNewOrExisting'), 'new')]",
             "name": "networkSecurityLinkedTemplate",
             "properties": {
                 "mode": "Incremental",
@@ -1089,6 +1206,18 @@
                     },
                     "overrideHostName": {
                         "value": "[parameters('enableDNSConfiguration')]"
+                    },
+                    "virtualNetworkNewOrExisting": {
+                        "value": "[parameters('virtualNetworkNewOrExisting')]"
+                    },
+                    "virtualNetworkResourceGroupName": {
+                        "value": "[parameters('virtualNetworkResourceGroupName')]"
+                    },
+                    "virtualNetworkName": {
+                        "value": "[parameters('virtualNetworkName')]"
+                    },
+                    "subnetForAppGateway": {
+                        "value": "[parameters('subnetForAppGateway')]"
                     },
                     "wlsDomainName": {
                         "value": "[parameters('wlsDomainName')]"
@@ -1504,11 +1633,20 @@
                     "storageAccountName": {
                         "value": "[reference(variables('clusterTemplateRef'), '${azure.apiVersion}').outputs.storageAccountName.value]"
                     },
+                    "subnetName": {
+                        "value": "[parameters('subnetName')]"
+                    },
                     "usePreviewImage": {
                         "value": "[parameters('usePreviewImage')]"
                     },
                     "vmSizeSelectForCoherence": {
                         "value": "[parameters('vmSizeSelectForCoherence')]"
+                    },
+                    "virtualNetworkResourceGroupName": {
+                        "value": "[parameters('virtualNetworkResourceGroupName')]"
+                    },
+                    "virtualNetworkName": {
+                        "value": "[parameters('virtualNetworkName')]"
                     },
                     "wlsDomainName": {
                         "value": "[parameters('wlsDomainName')]"
@@ -1735,7 +1873,7 @@
         },
         "appGatewaySecuredURL": {
             "type": "string",
-            "value": "[if(parameters('enableAppGateway'), if(parameters('enableDNSConfiguration'), uri('https://{0}.{1}', parameters('dnszoneAppGatewayLabel'),parameters('dnszoneName')), reference('keyVaultLinkedAppGatewayTemplate', '${azure.apiVersion}').outputs.appGatewaySecuredURL.value),'')]"
+            "value": "[if(parameters('enableAppGateway'), if(parameters('enableDNSConfiguration'), uri(concat('https://',parameters('dnszoneAppGatewayLabel'),'.',parameters('dnszoneName')),''), reference('keyVaultLinkedAppGatewayTemplate', '${azure.apiVersion}').outputs.appGatewaySecuredURL.value),'')]"
         },
         "logIndex": {
             "type": "string",

--- a/weblogic-azure-vm/arm-oraclelinux-wls-cluster/arm-oraclelinux-wls-cluster/src/main/arm/nestedtemplates/_keyvaultAppGatewayConnectorTemplate.json
+++ b/weblogic-azure-vm/arm-oraclelinux-wls-cluster/arm-oraclelinux-wls-cluster/src/main/arm/nestedtemplates/_keyvaultAppGatewayConnectorTemplate.json
@@ -133,6 +133,38 @@
                 "description": "If true, will override the host name with dnszoneSubDomain."
             }
         },
+        "virtualNetworkNewOrExisting": {
+            "type": "string",
+            "defaultValue": "new",
+            "allowedValues": [
+                "new",
+                "existing"
+            ],
+            "metadata": {
+                "description": "Specify whether to create a new or existing virtual network for the VM."
+            }
+        },
+        "virtualNetworkName": {
+            "type": "string",
+            "defaultValue": "wls-vnet",
+            "metadata": {
+                "description": "Name of the existing or new VNET"
+            }
+        },
+        "virtualNetworkResourceGroupName": {
+            "type": "string",
+            "defaultValue": "[resourceGroup().name]",
+            "metadata": {
+                "description": "Resource group of Virtual network"
+            }
+        },
+        "subnetForAppGateway": {
+            "type": "string",
+            "defaultValue": "appgateway-subnet",
+            "metadata": {
+                "description": "Name of the existing or new Subnet for Application Gateway"
+            }
+        },
         "wlsDomainName": {
             "defaultValue": "wlsd",
             "type": "string",
@@ -220,6 +252,18 @@
                     "overrideHostName": {
                         "value": "[parameters('overrideHostName')]"
                     },
+                    "virtualNetworkNewOrExisting": {
+                        "value": "[parameters('virtualNetworkNewOrExisting')]"
+                    },
+                    "virtualNetworkName": {
+                        "value": "[parameters('virtualNetworkName')]"
+                    },
+                    "virtualNetworkResourceGroupName": {
+                        "value": "[parameters('virtualNetworkResourceGroupName')]"
+                    },
+                    "subnetForAppGateway": {
+                        "value": "[parameters('subnetForAppGateway')]"
+                    },
                     "wlsDomainName": {
                         "value": "[parameters('wlsDomainName')]"
                     },
@@ -290,6 +334,18 @@
                     "overrideHostName": {
                         "value": "[parameters('overrideHostName')]"
                     },
+                    "virtualNetworkNewOrExisting": {
+                        "value": "[parameters('virtualNetworkNewOrExisting')]"
+                    },
+                    "virtualNetworkName": {
+                        "value": "[parameters('virtualNetworkName')]"
+                    },
+                    "virtualNetworkResourceGroupName": {
+                        "value": "[parameters('virtualNetworkResourceGroupName')]"
+                    },
+                    "subnetForAppGateway": {
+                        "value": "[parameters('subnetForAppGateway')]"
+                    },
                     "wlsDomainName": {
                         "value": "[parameters('wlsDomainName')]"
                     },
@@ -354,6 +410,18 @@
                     },
                     "overrideHostName": {
                         "value": "[parameters('overrideHostName')]"
+                    },
+                    "virtualNetworkNewOrExisting": {
+                        "value": "[parameters('virtualNetworkNewOrExisting')]"
+                    },
+                    "virtualNetworkName": {
+                        "value": "[parameters('virtualNetworkName')]"
+                    },
+                    "virtualNetworkResourceGroupName": {
+                        "value": "[parameters('virtualNetworkResourceGroupName')]"
+                    },
+                    "subnetForAppGateway": {
+                        "value": "[parameters('subnetForAppGateway')]"
                     },
                     "wlsDomainName": {
                         "value": "[parameters('wlsDomainName')]"

--- a/weblogic-azure-vm/arm-oraclelinux-wls-cluster/arm-oraclelinux-wls-cluster/src/main/arm/nestedtemplates/appGatewayNestedTemplate.json
+++ b/weblogic-azure-vm/arm-oraclelinux-wls-cluster/arm-oraclelinux-wls-cluster/src/main/arm/nestedtemplates/appGatewayNestedTemplate.json
@@ -89,6 +89,38 @@
 				"description": "If true, will override the host name with dnszoneSubDomain."
 			}
 		},
+        "virtualNetworkNewOrExisting": {
+            "type": "string",
+            "defaultValue": "new",
+            "allowedValues": [
+                "new",
+                "existing"
+            ],
+            "metadata": {
+                "description": "Specify whether to create a new or existing virtual network for the VM."
+            }
+        },
+		"virtualNetworkName": {
+            "type": "string",
+            "defaultValue": "wls-vnet",
+            "metadata": {
+                "description": "Name of the existing or new VNET"
+            }
+        },
+        "virtualNetworkResourceGroupName": {
+            "type": "string",
+            "defaultValue": "[resourceGroup().name]",
+            "metadata": {
+                "description": "Resource group of Virtual network"
+            }
+        },
+        "subnetForAppGateway": {
+            "type": "string",
+            "defaultValue": "appgateway-subnet",
+            "metadata": {
+                "description": "Name of the existing or new Subnet for Application Gateway"
+            }
+        },
 		"wlsDomainName": {
 			"defaultValue": "wlsd",
 			"type": "string",
@@ -116,11 +148,13 @@
 		"const_appGatewayFrontEndHTTPSPort": 443,
 		"const_backendPort": 8001,
 		"const_managedVMPrefix": "[concat(parameters('managedServerPrefix'),'VM')]",
+        "name_nic_with_pub_ip": "_NIC_with_pub_ip",
+        "name_nic_without_pub_ip": "_NIC_without_pub_ip",
 		"const_wlsAdminPort": "7005",
 		"const_wlsHome": "/u01/app/wls/install/oracle/middleware/oracle_home",
 		"name_appGateway": "myAppGateway",
 		"name_appGatewayCertificate": "appGwSslCertificate",
-		"name_appGatewaySubnet": "appGatewaySubnet",
+		"name_appGatewaySubnet": "[parameters('subnetForAppGateway')]",
 		"name_backendAddressPool": "myGatewayBackendPool",
 		"name_frontEndIPConfig": "appGwPublicFrontendIp",
 		"name_httpListener": "HTTPListener",
@@ -130,7 +164,7 @@
 		"name_httpsPort": "https_port",
 		"name_probe": "HTTPhealthProbe",
 		"name_scriptAGWConfiguration": "setupApplicationGateway.sh",
-		"name_virtualNetwork": "[concat(parameters('wlsDomainName'),'_VNET')]",
+		"name_virtualNetwork": "[parameters('virtualNetworkName')]",
 		"obj_HTTPSettingsDefault": {
 			"provisioningState": "Succeeded",
 			"port": "[int(variables('const_backendPort'))]",
@@ -157,7 +191,7 @@
 			}
 		},
 		"ref_appGatewayPublicIP": "[resourceId('Microsoft.Network/publicIPAddresses',parameters('gatewayPublicIPAddressName'))]",
-		"ref_appGatewaySubnet": "[resourceId('Microsoft.Network/virtualNetworks/subnets', variables('name_virtualNetwork'), variables('name_appGatewaySubnet'))]",
+		"ref_appGatewaySubnet": "[resourceId(parameters('virtualNetworkResourceGroupName'),'Microsoft.Network/virtualNetworks/subnets', variables('name_virtualNetwork'), variables('name_appGatewaySubnet'))]",
 		"ref_backendAddressPool": "[resourceId('Microsoft.Network/applicationGateways/backendAddressPools', variables('name_appGateway'),variables('name_backendAddressPool'))]",
 		"ref_backendHttpSettings": "[resourceId('Microsoft.Network/applicationGateways/backendHttpSettingsCollection', variables('name_appGateway'),variables('name_httpSetting'))]",
 		"ref_backendProbe": "[resourceId('Microsoft.Network/applicationGateways/probes', variables('name_appGateway'),variables('name_probe'))]",
@@ -267,7 +301,7 @@
 									"name": "BackendAddresses",
 									"count": "[sub(int(parameters('numberOfInstances')),1)]",
 									"input": {
-										"ipAddress": "[reference(resourceId('Microsoft.Network/networkInterfaces', concat(variables('const_managedVMPrefix'), copyIndex('BackendAddresses',1), '_NIC')),'${azure.apiVersionForNetworkInterfaces}').ipConfigurations[0].properties.privateIPAddress]"
+										"ipAddress": "[reference(resourceId('Microsoft.Network/networkInterfaces', concat(variables('const_managedVMPrefix'), copyIndex('BackendAddresses',1), if(equals(parameters('virtualNetworkNewOrExisting'), 'new'), variables('name_nic_with_pub_ip'), variables('name_nic_without_pub_ip')))),'${azure.apiVersionForNetworkInterfaces}').ipConfigurations[0].properties.privateIPAddress]"
 									}
 								}
 							]

--- a/weblogic-azure-vm/arm-oraclelinux-wls-cluster/arm-oraclelinux-wls-cluster/src/main/arm/nestedtemplates/clusterCustomSSLTemplate.json
+++ b/weblogic-azure-vm/arm-oraclelinux-wls-cluster/arm-oraclelinux-wls-cluster/src/main/arm/nestedtemplates/clusterCustomSSLTemplate.json
@@ -130,6 +130,68 @@
                 "description": "Select appropriate VM Size as per requirement"
             }
         },
+                "virtualNetworkNewOrExisting": {
+            "type": "string",
+            "defaultValue": "new",
+            "allowedValues": [
+               "new",
+               "existing"
+            ],
+            "metadata": {
+               "description": "Specify whether to create a new or existing virtual network for the VM."
+            }
+         },
+         "virtualNetworkName": {
+            "type": "string",
+            "defaultValue": "wls-vnet",
+            "metadata": {
+               "description": "Name of the existing or new VNET"
+            }
+         },
+         "virtualNetworkResourceGroupName": {
+            "type": "string",
+            "defaultValue": "[resourceGroup().name]",
+            "metadata": {
+               "description": "Resource group of Virtual network"
+            }
+         },
+         "addressPrefixes": {
+            "type": "array",
+            "defaultValue": [
+               "10.0.0.0/28"
+            ],
+            "metadata": {
+               "description": "Address prefix of the VNET."
+            }
+         },
+         "subnetName": {
+            "type": "string",
+            "defaultValue": "wls-subnet",
+            "metadata": {
+               "description": "Name of the existing or new Subnet"
+            }
+         },
+         "subnetPrefix": {
+            "type": "string",
+            "defaultValue": "10.0.0.0/29",
+            "metadata": {
+               "description": "Address prefix of the subnet"
+            }
+         },
+        "subnetForAppGateway": {
+            "type": "string",
+            "defaultValue": "appgateway-subnet",
+            "metadata": {
+                "description": "Name of the existing or new Subnet for Application Gateway"
+            }
+        },
+        "subnetPrefixForAppGateway": {
+            "type": "string",
+            "defaultValue": "10.0.1.0/24",
+            "metadata": {
+                "description": "Address prefix of the subnet for Application Gateway"
+            }
+        },
         "wlsDomainName": {
             "type": "string",
             "metadata": {
@@ -147,6 +209,13 @@
             "type": "securestring",
             "metadata": {
                 "description": "Password for your Weblogic domain name"
+            }
+        },
+        "enableAppGateway": {
+            "defaultValue": false,
+            "type": "bool",
+            "metadata": {
+                "description": "If true, deploy an Azure App Gateway in front of the nodes of the cluster"
             }
         },
         "enableHTTPAdminListenPort":{
@@ -229,8 +298,8 @@
         }
     },
     "variables": {
-        "const_addressPrefix": "10.0.0.0/16",
-        "const_appGatewaySubnetPrefix": "10.0.1.0/24",
+        "const_addressPrefix": "[parameters('addressPrefixes')]",
+        "const_appGatewaySubnetPrefix": "[parameters('subnetPrefixForAppGateway')]",
         "const_hyphen": "-",
         "const_imageOffer": "[concat('weblogic',variables('const_hyphen'), split(variables('name_linuxImageOfferSKU'),variables('const_hyphen'))[1],variables('const_hyphen'),split(variables('name_linuxImageOfferSKU'),variables('const_hyphen'))[2],variables('const_hyphen'),split(variables('name_linuxImageOfferSKU'),variables('const_hyphen'))[3],if(parameters('usePreviewImage'),'-preview',''))]",
         "const_imagePublisher": "oracle",
@@ -250,30 +319,68 @@
         "const_publicIPAddressType": "Dynamic",
         "const_requiredPortrange": ",65200-65535,5556",
         "const_storageAccountType": "Standard_LRS",
-        "const_subnetPrefix": "10.0.0.0/24",
+        "const_subnetPrefix": "[parameters('subnetPrefix')]",
         "const_vmSize": "[parameters('vmSizeSelect')]",
         "const_wlsHome": "/u01/app/wls/install/oracle/middleware/oracle_home",
-        "name_appGatewaySubnet": "appGatewaySubnet",
+        "name_appGatewaySubnet": "[parameters('subnetForAppGateway')]",
         "name_availabilitySet": "WLSCluster-AvailabilitySet",
         "name_linuxImageOfferSKU": "[first(split(parameters('skuUrnVersion'), ';'))]",
         "name_linuxImageVersion": "[last(split(parameters('skuUrnVersion'),';'))]",
         "name_networkSecurityGroup": "[concat(parameters('dnsLabelPrefix'), '-nsg')]",
         "name_nic": "_NIC",
         "name_publicIPAddress": "_PublicIP",
-        "name_outputAdminHost": "[concat(parameters('adminVMName'),variables('name_publicIPAddress'))]",
+        "name_nic_with_pub_ip": "[concat(variables('name_nic'), '_with_pub_ip')]",
+        "name_nic_without_pub_ip": "[concat(variables('name_nic'), '_without_pub_ip')]",
+        "name_outputAdminHost_with_pub_ip": "[concat(parameters('adminVMName'),variables('name_publicIPAddress'))]",
+        "name_outputAdminHost_without_pub_ip": "[concat(parameters('adminVMName'),variables('name_nic_without_pub_ip'))]",
+        "name_privateSaEndpoint": "[concat(take(replace(parameters('guidValue'),'-',''),6),'saep')]",
         "name_scriptFile": "setupClusterDomain.sh",
         "name_share": "wlsshare",
         "name_storageAccount": "[concat(take(replace(parameters('guidValue'),'-',''),6),'olvm')]",
-        "name_subnet": "Subnet",
-        "name_virtualNetwork": "[concat(parameters('wlsDomainName'),'_VNET')]",
+        "name_subnet": "[parameters('subnetName')]",
+        "name_virtualNetwork": "[parameters('virtualNetworkName')]",
         "ref_fileService": "[resourceId('Microsoft.Storage/storageAccounts/fileServices', variables('name_storageAccount'), 'default')]",
         "ref_networkSecurityGroup": "[resourceId('Microsoft.Network/networkSecurityGroups', variables('name_networkSecurityGroup'))]",
         "ref_storage": "[resourceId('Microsoft.Storage/storageAccounts', variables('name_storageAccount'))]",
-        "ref_subnet": "[resourceId('Microsoft.Network/virtualNetworks/subnets', variables('name_virtualNetwork'), variables('name_subnet'))]",
+        "ref_subnet": "[resourceId(parameters('virtualNetworkResourceGroupName'),'Microsoft.Network/virtualNetworks/subnets', variables('name_virtualNetwork'), variables('name_subnet'))]",
         "name_customHostnameGeneratorscriptFile": "generateCustomHostNameVerifier.sh",
         "name_customHostnameVerifierJavaFile": "src/main/java/WebLogicCustomHostNameVerifier.java",
         "name_customHostnameValuesTemplate": "src/main/java/HostNameValuesTemplate.txt",
-        "name_customHostnameVerifierTest" : "src/test/java/WebLogicCustomHostNameVerifierTest.java"
+        "name_customHostnameVerifierTest" : "src/test/java/WebLogicCustomHostNameVerifierTest.java",
+        "property_subnet_with_app_gateway": [
+            {
+                "name": "[variables('name_subnet')]",
+                "properties": {
+                    "addressPrefix": "[variables('const_subnetPrefix')]",
+                    "networkSecurityGroup": {
+                        "id": "[variables('ref_networkSecurityGroup')]"
+                    }
+                }
+            },
+            {
+                // PENDING(edburns): Assume it is acceptable to create a subnet for the App Gateway, even if the user
+                // has not requested an App Gateway.  In support of this assumption we can note: the user may want an App 
+                // Gateway after deployment.
+                "name": "[variables('name_appGatewaySubnet')]",
+                "properties": {
+                    "addressPrefix": "[variables('const_appGatewaySubnetPrefix')]",
+                    "networkSecurityGroup": {
+                        "id": "[variables('ref_networkSecurityGroup')]"
+                    }
+                }
+            }
+        ],
+        "property_subnet_without_app_gateway": [
+            {
+                "name": "[variables('name_subnet')]",
+                "properties": {
+                    "addressPrefix": "[variables('const_subnetPrefix')]",
+                    "networkSecurityGroup": {
+                        "id": "[variables('ref_networkSecurityGroup')]"
+                    }
+                }
+            }
+        ]
     },
     "resources": [
         {
@@ -293,6 +400,7 @@
         {
             "apiVersion": "${azure.apiVersionForNetworkSecurityGroups}",
             "type": "Microsoft.Network/networkSecurityGroups",
+            "condition": "[equals(parameters('virtualNetworkNewOrExisting'), 'new')]",
             "name": "[variables('name_networkSecurityGroup')]",
             "location": "[parameters('location')]",
             "properties": {
@@ -362,12 +470,38 @@
             "sku": {
                 "name": "[variables('const_storageAccountType')]"
             },
-            "kind": "Storage",
+            "kind": "StorageV2",
             "properties": {
                 "supportsHttpsTrafficOnly": false
             },
             "dependsOn": [
                 "[variables('name_networkSecurityGroup')]"
+            ]
+        },
+        {
+            "apiVersion": "${azure.apiVersionForPrivateEndpoint}",
+            "name": "[variables('name_privateSaEndpoint')]",
+            "type": "Microsoft.Network/privateEndpoints",
+            "location": "[parameters('location')]",
+            "properties": {
+                  "privateLinkServiceConnections": [
+                     {
+                        "name": "[variables('name_privateSaEndpoint')]",
+                        "properties": {
+                              "privateLinkServiceId": "[resourceId('Microsoft.Storage/storageAccounts/', variables('name_storageAccount'))]",
+                              "groupIds": [
+                                 "file"
+                              ]
+                        }
+                     }
+                  ],
+                  "subnet": {
+                     "id": "[variables('ref_subnet')]"
+                  }
+            },
+            "dependsOn": [
+               "[resourceId('Microsoft.Storage/storageAccounts', variables('name_storageAccount'))]",
+               "[variables('name_virtualNetwork')]"
             ]
         },
         {
@@ -397,6 +531,7 @@
         {
             "apiVersion": "${azure.apiVersionForPublicIPAddresses}",
             "type": "Microsoft.Network/publicIPAddresses",
+            "condition": "[equals(parameters('virtualNetworkNewOrExisting'), 'new')]",
             "name": "[if(equals(copyIndex(),0),concat(parameters('adminVMName'),variables('name_publicIPAddress')),concat(variables('const_managedVMPrefix'), copyIndex(),variables('name_publicIPAddress')))]",
             "location": "[parameters('location')]",
             "copy": {
@@ -416,6 +551,7 @@
         {
             "apiVersion": "${azure.apiVersionForVirtualNetworks}",
             "type": "Microsoft.Network/virtualNetworks",
+            "condition": "[equals(parameters('virtualNetworkNewOrExisting'), 'new')]",
             "name": "[variables('name_virtualNetwork')]",
             "location": "[parameters('location')]",
             "dependsOn": [
@@ -423,42 +559,19 @@
             ],
             "properties": {
                 "addressSpace": {
-                    "addressPrefixes": [
-                        "[variables('const_addressPrefix')]"
-                    ]
+                    "addressPrefixes": "[variables('const_addressPrefix')]"
                 },
-                "subnets": [
-                    {
-                        "name": "[variables('name_subnet')]",
-                        "properties": {
-                            "addressPrefix": "[variables('const_subnetPrefix')]",
-                            "networkSecurityGroup": {
-                                "id": "[variables('ref_networkSecurityGroup')]"
-                            }
-                        }
-                    },
-                    {
-                        // PENDING(edburns): Assume it is acceptable to create a subnet for the App Gateway, even if the user
-                        // has not requested an App Gateway.  In support of this assumption we can note: the user may want an App 
-                        // Gateway after deployment.
-                        "name": "[variables('name_appGatewaySubnet')]",
-                        "properties": {
-                            "addressPrefix": "[variables('const_appGatewaySubnetPrefix')]",
-                            "networkSecurityGroup": {
-                                "id": "[variables('ref_networkSecurityGroup')]"
-                            }
-                        }
-                    }
-                ]
+                "subnets": "[if(parameters('enableAppGateway'), variables('property_subnet_with_app_gateway'), variables('property_subnet_without_app_gateway'))]"
+
             }
         },
         {
             "apiVersion": "${azure.apiVersionForNetworkInterfaces}",
             "type": "Microsoft.Network/networkInterfaces",
-            "name": "[if(equals(copyIndex(),0),concat(parameters('adminVMName'),variables('name_nic')),concat(variables('const_managedVMPrefix'), copyIndex(),variables('name_nic')))]",
-            "location": "[parameters('location')]",
+            "condition": "[equals(parameters('virtualNetworkNewOrExisting'), 'new')]",
+            "name": "[if(equals(copyIndex(),0),concat(parameters('adminVMName'),variables('name_nic_with_pub_ip')),concat(variables('const_managedVMPrefix'), copyIndex(),variables('name_nic_with_pub_ip')))]",            "location": "[parameters('location')]",
             "copy": {
-                "name": "nicLoop",
+                "name": "nicLoop_public_ip",
                 "count": "[parameters('numberOfInstances')]"
             },
             "dependsOn": [
@@ -483,6 +596,33 @@
                 "dnsSettings": {
                     "internalDnsNameLabel": "[if(equals(copyIndex(),0),parameters('adminVMName'),concat(variables('const_managedVMPrefix'), copyIndex()))]"
                 }
+            }
+        },
+        {
+            "type": "Microsoft.Network/networkInterfaces",
+            "apiVersion": "${azure.apiVersionForNetworkInterfaces}",
+            "condition": "[equals(parameters('virtualNetworkNewOrExisting'), 'existing')]",
+            "name": "[if(equals(copyIndex(),0),variables('name_outputAdminHost_without_pub_ip'),concat(variables('const_managedVMPrefix'), copyIndex(),variables('name_nic_without_pub_ip')))]",
+            "location": "[parameters('location')]",
+            "copy": {
+                "name": "nicLoop_private_ip",
+                "count": "[parameters('numberOfInstances')]"
+            },
+            "dependsOn": [
+                "[variables('name_virtualNetwork')]"
+            ],
+            "properties": {
+                "ipConfigurations": [
+                    {
+                        "name": "ipconfig1",
+                        "properties": {
+                            "privateIPAllocationMethod": "Dynamic",
+                            "subnet": {
+                                "id": "[variables('ref_subnet')]"
+                            }
+                        }
+                    }
+                ]
             }
         },
         {
@@ -511,8 +651,10 @@
                 "count": "[parameters('numberOfInstances')]"
             },
             "dependsOn": [
-                "nicLoop",
-                "[resourceId('Microsoft.Compute/availabilitySets/', variables('name_availabilitySet'))]"
+                "nicLoop_public_ip",
+                "nicLoop_private_ip",
+                "[resourceId('Microsoft.Compute/availabilitySets/', variables('name_availabilitySet'))]",
+                "[variables('name_privateSaEndpoint')]"
             ],
             "identity": "[if(parameters('useSystemAssignedManagedIdentity'), json('{\"type\":\"SystemAssigned\"}'), null())]",
             "properties": {
@@ -545,7 +687,7 @@
                 "networkProfile": {
                     "networkInterfaces": [
                         {
-                            "id": "[resourceId('Microsoft.Network/networkInterfaces',if(equals(copyIndex(),0),concat(parameters('adminVMName'),variables('name_nic')),concat(variables('const_managedVMPrefix'), copyIndex(),variables('name_nic'))))]"
+                            "id": "[if(equals(parameters('virtualNetworkNewOrExisting'), 'new'), resourceId('Microsoft.Network/networkInterfaces',if(equals(copyIndex(),0),concat(parameters('adminVMName'),variables('name_nic_with_pub_ip')),concat(variables('const_managedVMPrefix'), copyIndex(),variables('name_nic_with_pub_ip')))), resourceId('Microsoft.Network/networkInterfaces',if(equals(copyIndex(),0),variables('name_outputAdminHost_without_pub_ip'),concat(variables('const_managedVMPrefix'), copyIndex(),variables('name_nic_without_pub_ip')))))]"
                         }
                     ]
                 },
@@ -590,7 +732,7 @@
                     ]
                 },
                 "protectedSettings": {
-                    "commandToExecute": "[concat('sh',' ',variables('name_scriptFile'),' <<< \"',parameters('wlsDomainName'),' ',parameters('wlsUserName'),' ',parameters('wlsPassword'),' ',if(equals(copyIndex(),0),'admin',concat(parameters('managedServerPrefix'), copyIndex())),' ',parameters('adminVMName'),' ',variables('const_wlsHome'),' ',variables('name_storageAccount'),' ',listKeys(resourceId('Microsoft.Storage/storageAccounts', variables('name_storageAccount')), '${azure.apiVersion2}').keys[0].value,' ',variables('const_mountPointPath'),' ',string(parameters('enableHTTPAdminListenPort')),' ',string(parameters('enableCustomSSL')),' ',if(parameters('enableDNSConfiguration'),parameters('customDNSNameForAdminServer'),reference(variables('name_outputAdminHost'), '${azure.apiVersion}').dnsSettings.fqdn),' ',parameters('dnsLabelPrefix'),' ',parameters('location'),' ',base64(parameters('keyVaultCustomIdentityKeyStoreData')),' ',base64(parameters('keyVaultCustomIdentityKeyStorePassPhrase')),' ',base64(parameters('keyVaultCustomIdentityKeyStoreType')),' ',base64(parameters('keyVaultCustomTrustKeyStoreData')),' ',base64(parameters('keyVaultCustomTrustKeyStorePassPhrase')),' ',base64(parameters('keyVaultCustomTrustKeyStoreType')),' ',base64(parameters('keyVaultPrivateKeyAlias')),' ',base64(parameters('keyVaultPrivateKeyPassPhrase')),'\"')]"
+                    "commandToExecute": "[concat('sh',' ',variables('name_scriptFile'),' <<< \"',parameters('wlsDomainName'),' ',parameters('wlsUserName'),' ',parameters('wlsPassword'),' ',if(equals(copyIndex(),0),'admin',concat(parameters('managedServerPrefix'), copyIndex())),' ',parameters('adminVMName'),' ',variables('const_wlsHome'),' ',variables('name_storageAccount'),' ',listKeys(resourceId('Microsoft.Storage/storageAccounts', variables('name_storageAccount')), '${azure.apiVersion2}').keys[0].value,' ',variables('const_mountPointPath'),' ',string(parameters('enableHTTPAdminListenPort')),' ',string(parameters('enableCustomSSL')),' ',if(equals(parameters('virtualNetworkNewOrExisting'), 'new'), if(parameters('enableDNSConfiguration'),parameters('customDNSNameForAdminServer'),reference(variables('name_outputAdminHost_with_pub_ip'), '${azure.apiVersion}').dnsSettings.fqdn), reference(variables('name_outputAdminHost_without_pub_ip')).ipConfigurations[0].properties.privateIPAddress),' ',parameters('dnsLabelPrefix'),' ',parameters('location'),' ', parameters('virtualNetworkNewOrExisting'),' ',reference(resourceId('Microsoft.Network/privateEndpoints/', variables('name_privateSaEndpoint')), '${azure.apiVersionForPrivateEndpoint}').customDnsConfigs[0].ipAddresses[0],' ',base64(parameters('keyVaultCustomIdentityKeyStoreData')),' ',base64(parameters('keyVaultCustomIdentityKeyStorePassPhrase')),' ',base64(parameters('keyVaultCustomIdentityKeyStoreType')),' ',base64(parameters('keyVaultCustomTrustKeyStoreData')),' ',base64(parameters('keyVaultCustomTrustKeyStorePassPhrase')),' ',base64(parameters('keyVaultCustomTrustKeyStoreType')),' ',base64(parameters('keyVaultPrivateKeyAlias')),' ',base64(parameters('keyVaultPrivateKeyPassPhrase')),'\"')]"
                 }
             }
         },
@@ -761,7 +903,7 @@
     "outputs": {
         "_adminPublicIPId": {
             "type": "string",
-            "value": "[resourceId('Microsoft.Network/publicIPAddresses',concat(parameters('adminVMName'),variables('name_publicIPAddress')))]"
+            "value": "[if(equals(parameters('virtualNetworkNewOrExisting'), 'new'),resourceId('Microsoft.Network/publicIPAddresses',concat(parameters('adminVMName'),variables('name_publicIPAddress'))),'')]"
         },
         "artifactsLocationPassedIn": {
             "type": "string",
@@ -769,15 +911,15 @@
         },
         "adminHostName": {
             "type": "string",
-            "value": "[reference(variables('name_outputAdminHost'), '${azure.apiVersion}').dnsSettings.fqdn]"
+            "value": "[if(equals(parameters('virtualNetworkNewOrExisting'), 'new'), reference(variables('name_outputAdminHost_with_pub_ip'), '${azure.apiVersion}').dnsSettings.fqdn, reference(variables('name_outputAdminHost_without_pub_ip')).ipConfigurations[0].properties.privateIPAddress)]"
         },
         "adminConsole": {
             "type": "string",
-            "value": "[concat('http://',reference(variables('name_outputAdminHost'), '${azure.apiVersion}').dnsSettings.fqdn,':7001/console')]"
+            "value": "[uri(concat('http://',if(equals(parameters('virtualNetworkNewOrExisting'), 'new'),reference(variables('name_outputAdminHost_with_pub_ip'), '${azure.apiVersion}').dnsSettings.fqdn,reference(variables('name_outputAdminHost_without_pub_ip')).ipConfigurations[0].properties.privateIPAddress),':7001/console'),'/')]"
         },
         "adminSecuredConsole": {
             "type": "string",
-            "value": "[concat('https://',reference(variables('name_outputAdminHost'), '${azure.apiVersion}').dnsSettings.fqdn,':7002/console')]"
+            "value": "[uri(concat('https://',if(equals(parameters('virtualNetworkNewOrExisting'), 'new'),reference(variables('name_outputAdminHost_with_pub_ip'), '${azure.apiVersion}').dnsSettings.fqdn,reference(variables('name_outputAdminHost_without_pub_ip')).ipConfigurations[0].properties.privateIPAddress),':7002/console'),'/')]"
         },
         "wlsDomainLocation": {
             "type": "string",

--- a/weblogic-azure-vm/arm-oraclelinux-wls-cluster/arm-oraclelinux-wls-cluster/src/main/arm/nestedtemplates/clusterTemplate.json
+++ b/weblogic-azure-vm/arm-oraclelinux-wls-cluster/arm-oraclelinux-wls-cluster/src/main/arm/nestedtemplates/clusterTemplate.json
@@ -130,6 +130,68 @@
                 "description": "Select appropriate VM Size as per requirement"
             }
         },
+        "virtualNetworkNewOrExisting": {
+            "type": "string",
+            "defaultValue": "new",
+            "allowedValues": [
+               "new",
+               "existing"
+            ],
+            "metadata": {
+               "description": "Specify whether to create a new or existing virtual network for the VM."
+            }
+         },
+         "virtualNetworkName": {
+            "type": "string",
+            "defaultValue": "wls-vnet",
+            "metadata": {
+               "description": "Name of the existing or new VNET"
+            }
+         },
+         "virtualNetworkResourceGroupName": {
+            "type": "string",
+            "defaultValue": "[resourceGroup().name]",
+            "metadata": {
+               "description": "Resource group of Virtual network"
+            }
+         },
+         "addressPrefixes": {
+            "type": "array",
+            "defaultValue": [
+               "10.0.0.0/28"
+            ],
+            "metadata": {
+               "description": "Address prefix of the VNET."
+            }
+         },
+         "subnetName": {
+            "type": "string",
+            "defaultValue": "wls-subnet",
+            "metadata": {
+               "description": "Name of the existing or new Subnet"
+            }
+         },
+         "subnetPrefix": {
+            "type": "string",
+            "defaultValue": "10.0.0.0/29",
+            "metadata": {
+               "description": "Address prefix of the subnet"
+            }
+         },
+        "subnetForAppGateway": {
+            "type": "string",
+            "defaultValue": "appgateway-subnet",
+            "metadata": {
+                "description": "Name of the existing or new Subnet for Application Gateway"
+            }
+        },
+        "subnetPrefixForAppGateway": {
+            "type": "string",
+            "defaultValue": "10.0.1.0/24",
+            "metadata": {
+                "description": "Address prefix of the subnet for Application Gateway"
+            }
+        },
         "wlsDomainName": {
             "type": "string",
             "metadata": {
@@ -163,6 +225,13 @@
                 "description": "Boolean value indicating, if DNS Zone Configuration is enabled or not"
             }
         },
+        "enableAppGateway": {
+            "defaultValue": false,
+            "type": "bool",
+            "metadata": {
+                "description": "If true, deploy an Azure App Gateway in front of the nodes of the cluster"
+            }
+        },
         "customDNSNameForAdminServer": {
             "type": "string",
             "defaultValue": "none",
@@ -172,8 +241,8 @@
         }
     },
     "variables": {
-        "const_addressPrefix": "10.0.0.0/16",
-        "const_appGatewaySubnetPrefix": "10.0.1.0/24",
+        "const_addressPrefix": "[parameters('addressPrefixes')]",
+        "const_appGatewaySubnetPrefix": "[parameters('subnetPrefixForAppGateway')]",
         "const_hyphen": "-",
         "const_imageOffer": "[concat('weblogic',variables('const_hyphen'), split(variables('name_linuxImageOfferSKU'),variables('const_hyphen'))[1],variables('const_hyphen'),split(variables('name_linuxImageOfferSKU'),variables('const_hyphen'))[2],variables('const_hyphen'),split(variables('name_linuxImageOfferSKU'),variables('const_hyphen'))[3],if(parameters('usePreviewImage'),'-preview',''))]",
         "const_imagePublisher": "oracle",
@@ -193,30 +262,68 @@
         "const_publicIPAddressType": "Dynamic",
         "const_requiredPortrange": ",65200-65535,5556",
         "const_storageAccountType": "Standard_LRS",
-        "const_subnetPrefix": "10.0.0.0/24",
+        "const_subnetPrefix": "[parameters('subnetPrefix')]",
         "const_vmSize": "[parameters('vmSizeSelect')]",
         "const_wlsHome": "/u01/app/wls/install/oracle/middleware/oracle_home",
-        "name_appGatewaySubnet": "appGatewaySubnet",
+        "name_appGatewaySubnet": "[parameters('subnetForAppGateway')]",
         "name_availabilitySet": "WLSCluster-AvailabilitySet",
         "name_linuxImageOfferSKU": "[first(split(parameters('skuUrnVersion'), ';'))]",
         "name_linuxImageVersion": "[last(split(parameters('skuUrnVersion'),';'))]",
         "name_networkSecurityGroup": "[concat(parameters('dnsLabelPrefix'), '-nsg')]",
         "name_nic": "_NIC",
+        "name_nic_with_pub_ip": "[concat(variables('name_nic'), '_with_pub_ip')]",
+        "name_nic_without_pub_ip": "[concat(variables('name_nic'), '_without_pub_ip')]",
         "name_publicIPAddress": "_PublicIP",
-        "name_outputAdminHost": "[concat(parameters('adminVMName'),variables('name_publicIPAddress'))]",
+        "name_outputAdminHost_with_pub_ip": "[concat(parameters('adminVMName'),variables('name_publicIPAddress'))]",
+        "name_outputAdminHost_without_pub_ip": "[concat(parameters('adminVMName'),variables('name_nic_without_pub_ip'))]",
+        "name_privateSaEndpoint": "[concat(take(replace(parameters('guidValue'),'-',''),6),'saep')]",
         "name_scriptFile": "setupClusterDomain.sh",
         "name_share": "wlsshare",
         "name_storageAccount": "[concat(take(replace(parameters('guidValue'),'-',''),6),'olvm')]",
-        "name_subnet": "Subnet",
-        "name_virtualNetwork": "[concat(parameters('wlsDomainName'),'_VNET')]",
+        "name_subnet": "[parameters('subnetName')]",
+        "name_virtualNetwork": "[parameters('virtualNetworkName')]",
         "ref_fileService": "[resourceId('Microsoft.Storage/storageAccounts/fileServices', variables('name_storageAccount'), 'default')]",
         "ref_networkSecurityGroup": "[resourceId('Microsoft.Network/networkSecurityGroups', variables('name_networkSecurityGroup'))]",
         "ref_storage": "[resourceId('Microsoft.Storage/storageAccounts', variables('name_storageAccount'))]",
-        "ref_subnet": "[resourceId('Microsoft.Network/virtualNetworks/subnets', variables('name_virtualNetwork'), variables('name_subnet'))]",
+        "ref_subnet": "[resourceId(parameters('virtualNetworkResourceGroupName'),'Microsoft.Network/virtualNetworks/subnets', variables('name_virtualNetwork'), variables('name_subnet'))]",
         "name_customHostnameGeneratorscriptFile": "generateCustomHostNameVerifier.sh",
         "name_customHostnameVerifierJavaFile": "src/main/java/WebLogicCustomHostNameVerifier.java",
         "name_customHostnameValuesTemplate": "src/main/java/HostNameValuesTemplate.txt",
-        "name_customHostnameVerifierTest" : "src/test/java/WebLogicCustomHostNameVerifierTest.java"
+        "name_customHostnameVerifierTest" : "src/test/java/WebLogicCustomHostNameVerifierTest.java",
+        "property_subnet_with_app_gateway": [
+            {
+                "name": "[variables('name_subnet')]",
+                "properties": {
+                    "addressPrefix": "[variables('const_subnetPrefix')]",
+                    "networkSecurityGroup": {
+                        "id": "[variables('ref_networkSecurityGroup')]"
+                    }
+                }
+            },
+            {
+                // PENDING(edburns): Assume it is acceptable to create a subnet for the App Gateway, even if the user
+                // has not requested an App Gateway.  In support of this assumption we can note: the user may want an App 
+                // Gateway after deployment.
+                "name": "[variables('name_appGatewaySubnet')]",
+                "properties": {
+                    "addressPrefix": "[variables('const_appGatewaySubnetPrefix')]",
+                    "networkSecurityGroup": {
+                        "id": "[variables('ref_networkSecurityGroup')]"
+                    }
+                }
+            }
+        ],
+        "property_subnet_without_app_gateway": [
+            {
+                "name": "[variables('name_subnet')]",
+                "properties": {
+                    "addressPrefix": "[variables('const_subnetPrefix')]",
+                    "networkSecurityGroup": {
+                        "id": "[variables('ref_networkSecurityGroup')]"
+                    }
+                }
+            }
+        ]
 
     },
     "resources": [
@@ -237,6 +344,7 @@
         {
             "apiVersion": "${azure.apiVersionForNetworkSecurityGroups}",
             "type": "Microsoft.Network/networkSecurityGroups",
+            "condition": "[equals(parameters('virtualNetworkNewOrExisting'), 'new')]",
             "name": "[variables('name_networkSecurityGroup')]",
             "location": "[parameters('location')]",
             "properties": {
@@ -306,12 +414,38 @@
             "sku": {
                 "name": "[variables('const_storageAccountType')]"
             },
-            "kind": "Storage",
+            "kind": "StorageV2",
             "properties": {
                 "supportsHttpsTrafficOnly": false
             },
             "dependsOn": [
                 "[variables('name_networkSecurityGroup')]"
+            ]
+        },
+        {
+            "apiVersion": "${azure.apiVersionForPrivateEndpoint}",
+            "name": "[variables('name_privateSaEndpoint')]",
+            "type": "Microsoft.Network/privateEndpoints",
+            "location": "[parameters('location')]",
+            "properties": {
+                  "privateLinkServiceConnections": [
+                     {
+                        "name": "[variables('name_privateSaEndpoint')]",
+                        "properties": {
+                              "privateLinkServiceId": "[resourceId('Microsoft.Storage/storageAccounts/', variables('name_storageAccount'))]",
+                              "groupIds": [
+                                 "file"
+                              ]
+                        }
+                     }
+                  ],
+                  "subnet": {
+                     "id": "[variables('ref_subnet')]"
+                  }
+            },
+            "dependsOn": [
+               "[resourceId('Microsoft.Storage/storageAccounts', variables('name_storageAccount'))]",
+               "[variables('name_virtualNetwork')]"
             ]
         },
         {
@@ -341,6 +475,7 @@
         {
             "apiVersion": "${azure.apiVersionForPublicIPAddresses}",
             "type": "Microsoft.Network/publicIPAddresses",
+            "condition": "[equals(parameters('virtualNetworkNewOrExisting'), 'new')]",
             "name": "[if(equals(copyIndex(),0),concat(parameters('adminVMName'),variables('name_publicIPAddress')),concat(variables('const_managedVMPrefix'), copyIndex(),variables('name_publicIPAddress')))]",
             "location": "[parameters('location')]",
             "copy": {
@@ -360,6 +495,7 @@
         {
             "apiVersion": "${azure.apiVersionForVirtualNetworks}",
             "type": "Microsoft.Network/virtualNetworks",
+            "condition": "[equals(parameters('virtualNetworkNewOrExisting'), 'new')]",
             "name": "[variables('name_virtualNetwork')]",
             "location": "[parameters('location')]",
             "dependsOn": [
@@ -367,42 +503,18 @@
             ],
             "properties": {
                 "addressSpace": {
-                    "addressPrefixes": [
-                        "[variables('const_addressPrefix')]"
-                    ]
+                    "addressPrefixes": "[variables('const_addressPrefix')]"
                 },
-                "subnets": [
-                    {
-                        "name": "[variables('name_subnet')]",
-                        "properties": {
-                            "addressPrefix": "[variables('const_subnetPrefix')]",
-                            "networkSecurityGroup": {
-                                "id": "[variables('ref_networkSecurityGroup')]"
-                            }
-                        }
-                    },
-                    {
-                        // PENDING(edburns): Assume it is acceptable to create a subnet for the App Gateway, even if the user
-                        // has not requested an App Gateway.  In support of this assumption we can note: the user may want an App 
-                        // Gateway after deployment.
-                        "name": "[variables('name_appGatewaySubnet')]",
-                        "properties": {
-                            "addressPrefix": "[variables('const_appGatewaySubnetPrefix')]",
-                            "networkSecurityGroup": {
-                                "id": "[variables('ref_networkSecurityGroup')]"
-                            }
-                        }
-                    }
-                ]
+                "subnets": "[if(parameters('enableAppGateway'), variables('property_subnet_with_app_gateway'), variables('property_subnet_without_app_gateway'))]"
             }
         },
         {
             "apiVersion": "${azure.apiVersionForNetworkInterfaces}",
             "type": "Microsoft.Network/networkInterfaces",
-            "name": "[if(equals(copyIndex(),0),concat(parameters('adminVMName'),variables('name_nic')),concat(variables('const_managedVMPrefix'), copyIndex(),variables('name_nic')))]",
-            "location": "[parameters('location')]",
+            "condition": "[equals(parameters('virtualNetworkNewOrExisting'), 'new')]",
+            "name": "[if(equals(copyIndex(),0),concat(parameters('adminVMName'),variables('name_nic_with_pub_ip')),concat(variables('const_managedVMPrefix'), copyIndex(),variables('name_nic_with_pub_ip')))]",            "location": "[parameters('location')]",
             "copy": {
-                "name": "nicLoop",
+                "name": "nicLoop_public_ip",
                 "count": "[parameters('numberOfInstances')]"
             },
             "dependsOn": [
@@ -427,6 +539,33 @@
                 "dnsSettings": {
                     "internalDnsNameLabel": "[if(equals(copyIndex(),0),parameters('adminVMName'),concat(variables('const_managedVMPrefix'), copyIndex()))]"
                 }
+            }
+        },
+        {
+            "type": "Microsoft.Network/networkInterfaces",
+            "apiVersion": "${azure.apiVersionForNetworkInterfaces}",
+            "condition": "[equals(parameters('virtualNetworkNewOrExisting'), 'existing')]",
+            "name": "[if(equals(copyIndex(),0),variables('name_outputAdminHost_without_pub_ip'),concat(variables('const_managedVMPrefix'), copyIndex(),variables('name_nic_without_pub_ip')))]",
+            "location": "[parameters('location')]",
+            "copy": {
+                "name": "nicLoop_private_ip",
+                "count": "[parameters('numberOfInstances')]"
+            },
+            "dependsOn": [
+                "[variables('name_virtualNetwork')]"
+            ],
+            "properties": {
+                "ipConfigurations": [
+                    {
+                        "name": "ipconfig1",
+                        "properties": {
+                            "privateIPAllocationMethod": "Dynamic",
+                            "subnet": {
+                                "id": "[variables('ref_subnet')]"
+                            }
+                        }
+                    }
+                ]
             }
         },
         {
@@ -455,8 +594,10 @@
                 "count": "[parameters('numberOfInstances')]"
             },
             "dependsOn": [
-                "nicLoop",
-                "[resourceId('Microsoft.Compute/availabilitySets/', variables('name_availabilitySet'))]"
+                "nicLoop_public_ip",
+                "nicLoop_private_ip",
+                "[resourceId('Microsoft.Compute/availabilitySets/', variables('name_availabilitySet'))]",
+                "[variables('name_privateSaEndpoint')]"
             ],
             "identity": "[if(parameters('useSystemAssignedManagedIdentity'), json('{\"type\":\"SystemAssigned\"}'), null())]",
             "properties": {
@@ -489,7 +630,7 @@
                 "networkProfile": {
                     "networkInterfaces": [
                         {
-                            "id": "[resourceId('Microsoft.Network/networkInterfaces',if(equals(copyIndex(),0),concat(parameters('adminVMName'),variables('name_nic')),concat(variables('const_managedVMPrefix'), copyIndex(),variables('name_nic'))))]"
+                            "id": "[if(equals(parameters('virtualNetworkNewOrExisting'), 'new'), resourceId('Microsoft.Network/networkInterfaces',if(equals(copyIndex(),0),concat(parameters('adminVMName'),variables('name_nic_with_pub_ip')),concat(variables('const_managedVMPrefix'), copyIndex(),variables('name_nic_with_pub_ip')))), resourceId('Microsoft.Network/networkInterfaces',if(equals(copyIndex(),0),variables('name_outputAdminHost_without_pub_ip'),concat(variables('const_managedVMPrefix'), copyIndex(),variables('name_nic_without_pub_ip')))))]"
                         }
                     ]
                 },
@@ -534,7 +675,7 @@
                     ]
                 },
                 "protectedSettings": {
-                    "commandToExecute": "[concat('sh',' ',variables('name_scriptFile'),' <<< \"',parameters('wlsDomainName'),' ',parameters('wlsUserName'),' ',parameters('wlsPassword'),' ',if(equals(copyIndex(),0),'admin',concat(parameters('managedServerPrefix'), copyIndex())),' ',parameters('adminVMName'),' ',variables('const_wlsHome'),' ',variables('name_storageAccount'),' ',listKeys(resourceId('Microsoft.Storage/storageAccounts', variables('name_storageAccount')), '${azure.apiVersion2}').keys[0].value,' ',variables('const_mountPointPath'),' ',string(parameters('enableHTTPAdminListenPort')),' ','false',' ',if(parameters('enableDNSConfiguration'),parameters('customDNSNameForAdminServer'),reference(variables('name_outputAdminHost'), '${azure.apiVersion}').dnsSettings.fqdn),' ',parameters('dnsLabelPrefix'),' ',parameters('location'),'\"')]"
+                    "commandToExecute": "[concat('sh',' ',variables('name_scriptFile'),' <<< \"',parameters('wlsDomainName'),' ',parameters('wlsUserName'),' ',parameters('wlsPassword'),' ',if(equals(copyIndex(),0),'admin',concat(parameters('managedServerPrefix'), copyIndex())),' ',parameters('adminVMName'),' ',variables('const_wlsHome'),' ',variables('name_storageAccount'),' ',listKeys(resourceId('Microsoft.Storage/storageAccounts', variables('name_storageAccount')), '${azure.apiVersion2}').keys[0].value,' ',variables('const_mountPointPath'),' ',string(parameters('enableHTTPAdminListenPort')),' ','false',' ',if(equals(parameters('virtualNetworkNewOrExisting'), 'new'), if(parameters('enableDNSConfiguration'),parameters('customDNSNameForAdminServer'),reference(variables('name_outputAdminHost_with_pub_ip'), '${azure.apiVersion}').dnsSettings.fqdn), reference(variables('name_outputAdminHost_without_pub_ip')).ipConfigurations[0].properties.privateIPAddress),' ',parameters('dnsLabelPrefix'),' ',parameters('location'), ' ', parameters('virtualNetworkNewOrExisting'),' ',reference(resourceId('Microsoft.Network/privateEndpoints/', variables('name_privateSaEndpoint')), '${azure.apiVersionForPrivateEndpoint}').customDnsConfigs[0].ipAddresses[0],'\"')]"
                 }
             }
         },
@@ -707,7 +848,7 @@
     "outputs": {
         "_adminPublicIPId": {
             "type": "string",
-            "value": "[resourceId('Microsoft.Network/publicIPAddresses',concat(parameters('adminVMName'),variables('name_publicIPAddress')))]"
+            "value": "[if(equals(parameters('virtualNetworkNewOrExisting'), 'new'),resourceId('Microsoft.Network/publicIPAddresses',concat(parameters('adminVMName'),variables('name_publicIPAddress'))),'')]"
         },
         "artifactsLocationPassedIn": {
             "type": "string",
@@ -715,15 +856,15 @@
         },
         "adminHostName": {
             "type": "string",
-            "value": "[reference(variables('name_outputAdminHost'), '${azure.apiVersion}').dnsSettings.fqdn]"
+            "value": "[if(equals(parameters('virtualNetworkNewOrExisting'), 'new'), reference(variables('name_outputAdminHost_with_pub_ip'), '${azure.apiVersion}').dnsSettings.fqdn, reference(variables('name_outputAdminHost_without_pub_ip')).ipConfigurations[0].properties.privateIPAddress)]"
         },
         "adminConsole": {
             "type": "string",
-            "value": "[concat('http://',reference(variables('name_outputAdminHost'), '${azure.apiVersion}').dnsSettings.fqdn,':7001/console')]"
+            "value": "[uri(concat('http://',if(equals(parameters('virtualNetworkNewOrExisting'), 'new'),reference(variables('name_outputAdminHost_with_pub_ip'), '${azure.apiVersion}').dnsSettings.fqdn,reference(variables('name_outputAdminHost_without_pub_ip')).ipConfigurations[0].properties.privateIPAddress),':7001/console'),'/')]"
         },
         "adminSecuredConsole": {
             "type": "string",
-            "value": "[concat('https://',reference(variables('name_outputAdminHost'), '${azure.apiVersion}').dnsSettings.fqdn,':7002/console')]"
+            "value": "[uri(concat('https://',if(equals(parameters('virtualNetworkNewOrExisting'), 'new'),reference(variables('name_outputAdminHost_with_pub_ip'), '${azure.apiVersion}').dnsSettings.fqdn,reference(variables('name_outputAdminHost_without_pub_ip')).ipConfigurations[0].properties.privateIPAddress),':7002/console'),'/')]"
         },
         "wlsDomainLocation": {
             "type": "string",

--- a/weblogic-azure-vm/arm-oraclelinux-wls-cluster/arm-oraclelinux-wls-cluster/src/main/arm/nestedtemplates/coherenceTemplate.json
+++ b/weblogic-azure-vm/arm-oraclelinux-wls-cluster/arm-oraclelinux-wls-cluster/src/main/arm/nestedtemplates/coherenceTemplate.json
@@ -159,6 +159,13 @@
                 "description": "Name of storage account. One storage account can store 20 vitual machines with 2 VHDs of 500 IOPS."
             }
         },
+        "subnetName": {
+            "type": "string",
+            "defaultValue": "wls-subnet",
+            "metadata": {
+               "description": "Name of the existing or new Subnet"
+            }
+        },
         "usePreviewImage": {
             "type": "bool",
             "defaultValue": false,
@@ -171,6 +178,20 @@
             "type": "string",
             "metadata": {
                 "description": "Select appropriate VM Size for Coherence cache server"
+            }
+        },
+        "virtualNetworkResourceGroupName": {
+            "type": "string",
+            "defaultValue": "[resourceGroup().name]",
+            "metadata": {
+                "description": "Resource group of Virtual network"
+            }
+        },
+        "virtualNetworkName": {
+            "type": "string",
+            "defaultValue": "wls-vnet",
+            "metadata": {
+                "description": "Name of the existing or new VNET"
             }
         },
         "wlsDomainName": {
@@ -299,11 +320,11 @@
         "name_scriptELKConfiguration": "elkIntegration.sh",
         "name_scriptFile": "setupCoherence.sh",
         "name_share": "wlsshare",
-        "name_subnet": "Subnet",
-        "name_virtualNetwork": "[concat(parameters('wlsDomainName'),'_VNET')]",
+        "name_subnet": "[parameters('subnetName')]",
+        "name_virtualNetwork": "[parameters('virtualNetworkName')]",
         "name_vmMachine": "[concat(parameters('managedServerPrefix'),'StorageVM')]",
         "name_wlsServerPrefix": "[concat(parameters('managedServerPrefix'),'Storage')]",
-        "ref_subnet": "[resourceId('Microsoft.Network/virtualNetworks/subnets', variables('name_virtualNetwork'), variables('name_subnet'))]",
+        "ref_subnet": "[resourceId(parameters('virtualNetworkResourceGroupName'),'Microsoft.Network/virtualNetworks/subnets', variables('name_virtualNetwork'), variables('name_subnet'))]",
         "name_customHostnameGeneratorscriptFile": "generateCustomHostNameVerifier.sh",
         "name_customHostnameVerifierJavaFile": "src/main/java/WebLogicCustomHostNameVerifier.java",
         "name_customHostnameValuesTemplate": "src/main/java/HostNameValuesTemplate.txt",

--- a/weblogic-azure-vm/arm-oraclelinux-wls-cluster/arm-oraclelinux-wls-cluster/src/main/scripts/setupClusterDomain.sh
+++ b/weblogic-azure-vm/arm-oraclelinux-wls-cluster/arm-oraclelinux-wls-cluster/src/main/scripts/setupClusterDomain.sh
@@ -103,6 +103,18 @@ function validateInput()
             exit 1
         fi
     fi
+
+    if [ -z "$virtualNetworkNewOrExisting" ];
+    then
+        echo_stderr "virtualNetworkNewOrExisting is required. "
+        exit 1
+    fi
+
+    if [ -z "$storageAccountPrivateIp" ];
+    then
+        echo_stderr "storageAccountPrivateIp is required. "
+        exit 1
+    fi
 }
 
 #Function to cleanup all temporary files
@@ -624,13 +636,13 @@ function mountFileShare()
   fi
   echo "chmod 600 /etc/smbcredentials/${storageAccountName}.cred"
   sudo chmod 600 /etc/smbcredentials/${storageAccountName}.cred
-  echo "//${storageAccountName}.file.core.windows.net/wlsshare $mountpointPath cifs nofail,vers=2.1,credentials=/etc/smbcredentials/${storageAccountName}.cred,dir_mode=0777,file_mode=0777,serverino"
-  sudo bash -c "echo \"//${storageAccountName}.file.core.windows.net/wlsshare $mountpointPath cifs nofail,vers=2.1,credentials=/etc/smbcredentials/${storageAccountName}.cred,dir_mode=0777,file_mode=0777,serverino\" >> /etc/fstab"
-  echo "mount -t cifs //${storageAccountName}.file.core.windows.net/wlsshare $mountpointPath -o vers=2.1,credentials=/etc/smbcredentials/${storageAccountName}.cred,dir_mode=0777,file_mode=0777,serverino"
-  sudo mount -t cifs //${storageAccountName}.file.core.windows.net/wlsshare $mountpointPath -o vers=2.1,credentials=/etc/smbcredentials/${storageAccountName}.cred,dir_mode=0777,file_mode=0777,serverino
+  echo "//${storageAccountPrivateIp}/wlsshare $mountpointPath cifs nofail,vers=2.1,credentials=/etc/smbcredentials/${storageAccountName}.cred,dir_mode=0777,file_mode=0777,serverino"
+  sudo bash -c "echo \"//${storageAccountPrivateIp}/wlsshare $mountpointPath cifs nofail,vers=2.1,credentials=/etc/smbcredentials/${storageAccountName}.cred,dir_mode=0777,file_mode=0777,serverino\" >> /etc/fstab"
+  echo "mount -t cifs //${storageAccountPrivateIp}/wlsshare $mountpointPath -o vers=2.1,credentials=/etc/smbcredentials/${storageAccountName}.cred,dir_mode=0777,file_mode=0777,serverino"
+  sudo mount -t cifs //${storageAccountPrivateIp}/wlsshare $mountpointPath -o vers=2.1,credentials=/etc/smbcredentials/${storageAccountName}.cred,dir_mode=0777,file_mode=0777,serverino
   if [[ $? != 0 ]];
   then
-         echo "Failed to mount //${storageAccountName}.file.core.windows.net/wlsshare $mountpointPath"
+         echo "Failed to mount //${storageAccountPrivateIp}/wlsshare $mountpointPath"
 	 exit 1
   fi
 }
@@ -863,7 +875,7 @@ CURR_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
 BASE_DIR="$(readlink -f ${CURR_DIR})"
 
 #read arguments from stdin
-read wlsDomainName wlsUserName wlsPassword wlsServerName wlsAdminHost oracleHome storageAccountName storageAccountKey mountpointPath isHTTPAdminListenPortEnabled isCustomSSLEnabled customDNSNameForAdminServer dnsLabelPrefix location customIdentityKeyStoreData customIdentityKeyStorePassPhrase customIdentityKeyStoreType customTrustKeyStoreData customTrustKeyStorePassPhrase customTrustKeyStoreType serverPrivateKeyAlias serverPrivateKeyPassPhrase
+read wlsDomainName wlsUserName wlsPassword wlsServerName wlsAdminHost oracleHome storageAccountName storageAccountKey mountpointPath isHTTPAdminListenPortEnabled isCustomSSLEnabled customDNSNameForAdminServer dnsLabelPrefix location virtualNetworkNewOrExisting storageAccountPrivateIp customIdentityKeyStoreData customIdentityKeyStorePassPhrase customIdentityKeyStoreType customTrustKeyStoreData customTrustKeyStorePassPhrase customTrustKeyStoreType serverPrivateKeyAlias serverPrivateKeyPassPhrase
 
 isHTTPAdminListenPortEnabled="${isHTTPAdminListenPortEnabled,,}"
 isCustomSSLEnabled="${isCustomSSLEnabled,,}"


### PR DESCRIPTION
#163 wait until this issue get fixed

## What it supports:
* It allows users to choose an existing VNET when deploying WebLogic cluster servers.
* It allows users to choose an existing VNET when they choose to create Application Gateway along with WebLogic servers.
* It allows users to provide an existing VNET when adding node to an existing cluster.
What it DOES NOT support:
* Allow private IP address for Application Gateway.

## Code change

### Cluster offer
* Group networking related configurations under 'Networking' tab.
* Move 'Application Gateway' tab ahead of 'Networking' tab.
* Disable DNS configuration when deploying to an existing VNET.
* Not to create NSG when deploying to an existing VNET.
* Use 'StorageV2' Storage account to enable private endpoint, then mount file share with private IP address to avoid networking issues.

### Add node
* Parameterize VNET and subnet for addnode module.

### Pipeline
* Update `.github/workflows/testWlsVmCluster.yml` to work with latest code change. -- pending change before this PR is ready for review.
* Bugfix for other pipelines.

## Test cases

### ARM template & [preview offer](https://portal.azure.com/#create/microsoft_javaeeonazure_test.20210105-zhengchang-01-preview2021-zheng-cluster-test)
* SSL - new VNET - no Application Gateway
* SSL - new VNET - Application Gateway
* SSL - existing VNET - no Application Gateway
* SSL - existing VNET - Application Gateway
* No SSL - new VNET - no Application Gateway
* No SSL - new VNET - Application Gateway
* No SSL - existing VNET - Application Gateway
* No SSL - existing VNET - no Application Gateway
* SSL - existing VNET - Application Gateway - DB
* SSL - new VNET - Application Gateway - Custom DNS

### Pipeline

* [testWlsVmCluster.yml](https://github.com/zhengchang907/weblogic-azure/actions/runs/2526310915)

Signed-off-by: Zheng Chang <zhengchang@microsoft.com>