### PR TITLE
Add an info box to help user provide a workable vNet and subnet

### DIFF
--- a/weblogic-azure-aks/pom.xml
+++ b/weblogic-azure-aks/pom.xml
@@ -17,7 +17,7 @@
 
   <groupId>com.oracle.weblogic.azure</groupId>
   <artifactId>wls-on-aks-azure-marketplace</artifactId>
-  <version>1.0.39</version>
+  <version>1.0.40</version>
 
   <parent>
     <groupId>com.microsoft.azure.iaas</groupId>

--- a/weblogic-azure-aks/src/main/arm/createUiDefinition.json
+++ b/weblogic-azure-aks/src/main/arm/createUiDefinition.json
@@ -1395,6 +1395,15 @@
                                 }
                             },
                             {
+                                "name": "vnetInfo",
+                                "type": "Microsoft.Common.InfoBox",
+                                "visible": "[steps('section_appGateway').appgwIngress.enableAppGateway]",
+                                "options": {
+                                    "icon": "Info",
+                                    "text": "When creating a new virtual network, the subnet's address prefix is calculated automatically based on the virtual network's address prefix. When using an existing virtual network, a minimum virtual network size of /24 and a minimum subnet size of /24 are required. Additionally, the subnet must be dedicated only for use by the Application Gateway."
+                                }
+                            },
+                            {
                                 "name": "vnetForApplicationGateway",
                                 "type": "Microsoft.Network.VirtualNetworkCombo",
                                 "label": {
@@ -1424,7 +1433,7 @@
                                         },
                                         "constraints": {
                                             "minAddressPrefixSize": "/24",
-                                            "minAddressCount": 38,
+                                            "minAddressCount": 250,
                                             "requireContiguousAddresses": false
                                         }
                                     }


### PR DESCRIPTION
As the minimum vnet and subnet size are specified, and the subnet needs to be dedicated for the Application gateway, an info box is added to help user provide a workable vNet and subnet.

Leverage changes from https://github.com/WASdev/azure.liberty.aks/pull/51

Signed-off-by: galiacheng <haixia.cheng@microsoft.com>