### PR TITLE
Add an info box to help user provide a workable vNet and subnet

### DIFF
--- a/weblogic-azure-vm/arm-oraclelinux-wls-admin/pom.xml
+++ b/weblogic-azure-vm/arm-oraclelinux-wls-admin/pom.xml
@@ -10,7 +10,7 @@
 
     <groupId>com.oracle.weblogic.azure</groupId>
     <artifactId>arm-oraclelinux-wls-admin</artifactId>
-    <version>1.0.31</version>
+    <version>1.0.32</version>
     
     <parent>
         <groupId>com.microsoft.azure.iaas</groupId>

--- a/weblogic-azure-vm/arm-oraclelinux-wls-admin/src/main/arm/createUiDefinition.json
+++ b/weblogic-azure-vm/arm-oraclelinux-wls-admin/src/main/arm/createUiDefinition.json
@@ -741,6 +741,14 @@
                         }
                     },
                     {
+                        "name": "vnetInfo",
+                        "type": "Microsoft.Common.InfoBox",
+                        "options": {
+                            "icon": "Info",
+                            "text": "When creating a new virtual network, the subnet's address prefix is calculated automatically based on the virtual network's address prefix. When using an existing virtual network, a minimum virtual network size of /28 and a minimum subnet size of /29 are required. Additionally, the subnet must have adequate available addresses for the server setup."
+                        }
+                    },
+                    {
                         "name": "virtualNetwork",
                         "type": "Microsoft.Network.VirtualNetworkCombo",
                         "visible": "[steps('section_networkingConfiguration').customVnet]",


### PR DESCRIPTION
As the minimum vnet and subnet size are specified, and the subnet needs to be dedicated for the Application gateway, an info box is added to help user provide a workable vNet and subnet.

Leverage changes from https://github.com/WASdev/azure.liberty.aks/pull/51