### PR TITLE
Pass complicated db parameters with base64 string

### DIFF
--- a/weblogic-azure-vm/arm-oraclelinux-wls-admin/src/main/arm/nestedtemplates/dbTemplate.json
+++ b/weblogic-azure-vm/arm-oraclelinux-wls-admin/src/main/arm/nestedtemplates/dbTemplate.json
@@ -127,7 +127,7 @@
                     ]
                 },
                 "protectedSettings": {
-                    "commandToExecute": "[concat('sh',' ',variables('name_scriptFilePrefix'),parameters('databaseType'),'.sh <<< \"',variables('const_wlsHome'),' ',parameters('adminVMName'),' ',variables('const_wlsAdminPort'),' ',parameters('wlsUserName'),' ',parameters('wlsPassword'),' ',parameters('jdbcDataSourceName'),' ',parameters('dsConnectionURL'),' ',parameters('dbUser'),' ',parameters('dbPassword'), ' ', parameters('dbGlobalTranPro'), '\"')]"
+                    "commandToExecute": "[concat('sh',' ',variables('name_scriptFilePrefix'),parameters('databaseType'),'.sh <<< \"',variables('const_wlsHome'),' ',parameters('adminVMName'),' ',variables('const_wlsAdminPort'),' ',parameters('wlsUserName'),' ',base64(parameters('wlsPassword')),' ',base64(parameters('jdbcDataSourceName')),' ',base64(parameters('dsConnectionURL')),' ',parameters('dbUser'),' ',base64(parameters('dbPassword')), ' ', parameters('dbGlobalTranPro'), '\"')]"
                 }
             }
         },

--- a/weblogic-azure-vm/arm-oraclelinux-wls-admin/src/main/scripts/datasourceConfig-oracle.sh
+++ b/weblogic-azure-vm/arm-oraclelinux-wls-admin/src/main/scripts/datasourceConfig-oracle.sh
@@ -19,6 +19,11 @@ function usage()
 
 function validateInput()
 {
+   # parse base64 string
+   wlsPassword=$(echo "${wlsPassword}" | base64 -d)
+   jdbcDataSourceName=$(echo "${jdbcDataSourceName}" | base64 -d)
+   dsConnectionURL=$(echo "${dsConnectionURL}" | base64 -d)
+   dsPassword=$(echo "${dsPassword}" | base64 -d)
 
    if [ -z "$oracleHome" ];
    then
@@ -85,7 +90,6 @@ function validateInput()
        echo _stderr "Please provide Weblogic target cluster name"
        exit 1
    fi
-
 }
 
 function createJDBCSource_model()

--- a/weblogic-azure-vm/arm-oraclelinux-wls-admin/src/main/scripts/datasourceConfig-postgresql.sh
+++ b/weblogic-azure-vm/arm-oraclelinux-wls-admin/src/main/scripts/datasourceConfig-postgresql.sh
@@ -19,6 +19,11 @@ function usage()
 
 function validateInput()
 {
+   # parse base64 string
+   wlsPassword=$(echo "${wlsPassword}" | base64 -d)
+   jdbcDataSourceName=$(echo "${jdbcDataSourceName}" | base64 -d)
+   dsConnectionURL=$(echo "${dsConnectionURL}" | base64 -d)
+   dsPassword=$(echo "${dsPassword}" | base64 -d)
 
    if [ -z "$oracleHome" ];
    then
@@ -85,7 +90,6 @@ function validateInput()
        echo _stderr "Please provide Weblogic target cluster name"
        exit 1
    fi
-
 }
 
 function createJDBCSource_model()

--- a/weblogic-azure-vm/arm-oraclelinux-wls-admin/src/main/scripts/datasourceConfig-sqlserver.sh
+++ b/weblogic-azure-vm/arm-oraclelinux-wls-admin/src/main/scripts/datasourceConfig-sqlserver.sh
@@ -19,6 +19,11 @@ function usage()
 
 function validateInput()
 {
+   # parse base64 string
+   wlsPassword=$(echo "${wlsPassword}" | base64 -d)
+   jdbcDataSourceName=$(echo "${jdbcDataSourceName}" | base64 -d)
+   dsConnectionURL=$(echo "${dsConnectionURL}" | base64 -d)
+   dsPassword=$(echo "${dsPassword}" | base64 -d)
 
    if [ -z "$oracleHome" ];
    then
@@ -85,7 +90,6 @@ function validateInput()
        echo _stderr "Please provide Weblogic target cluster name"
        exit 1
    fi
-
 }
 
 function createJDBCSource_model()

--- a/weblogic-azure-vm/arm-oraclelinux-wls-cluster/arm-oraclelinux-wls-cluster/src/main/arm/nestedtemplates/dbTemplate.json
+++ b/weblogic-azure-vm/arm-oraclelinux-wls-cluster/arm-oraclelinux-wls-cluster/src/main/arm/nestedtemplates/dbTemplate.json
@@ -131,7 +131,7 @@
                     ]
                 },
                 "protectedSettings": {
-                    "commandToExecute": "[concat('sh',' ',variables('name_scriptFilePrefix'),parameters('databaseType'),'.sh <<< \"',variables('const_wlsHome'),' ',parameters('adminVMName'),' ',variables('const_wlsAdminPort'),' ',parameters('wlsUserName'),' ',parameters('wlsPassword'),' ',parameters('jdbcDataSourceName'),' ',parameters('dsConnectionURL'),' ',parameters('dbUser'),' ',parameters('dbPassword'), ' ',parameters('dbGlobalTranPro'), '\"')]"
+                    "commandToExecute": "[concat('sh',' ',variables('name_scriptFilePrefix'),parameters('databaseType'),'.sh <<< \"',variables('const_wlsHome'),' ',parameters('adminVMName'),' ',variables('const_wlsAdminPort'),' ',parameters('wlsUserName'),' ',base64(parameters('wlsPassword')),' ',base64(parameters('jdbcDataSourceName')),' ',base64(parameters('dsConnectionURL')),' ',parameters('dbUser'),' ',base64(parameters('dbPassword')), ' ',parameters('dbGlobalTranPro'), '\"')]"
                 }
             }
         },

--- a/weblogic-azure-vm/arm-oraclelinux-wls-cluster/arm-oraclelinux-wls-cluster/src/main/scripts/datasourceConfig-oracle.sh
+++ b/weblogic-azure-vm/arm-oraclelinux-wls-cluster/arm-oraclelinux-wls-cluster/src/main/scripts/datasourceConfig-oracle.sh
@@ -17,6 +17,11 @@ function usage()
 
 function validateInput()
 {
+   # parse base64 string
+   wlsPassword=$(echo "${wlsPassword}" | base64 -d)
+   jdbcDataSourceName=$(echo "${jdbcDataSourceName}" | base64 -d)
+   dsConnectionURL=$(echo "${dsConnectionURL}" | base64 -d)
+   dsPassword=$(echo "${dsPassword}" | base64 -d)
 
    if [ -z "$oracleHome" ];
    then
@@ -83,7 +88,6 @@ function validateInput()
        echo _stderr "Please provide Weblogic target cluster name"
        exit 1
    fi
-
 }
 
 function createJDBCSource_model()

--- a/weblogic-azure-vm/arm-oraclelinux-wls-cluster/arm-oraclelinux-wls-cluster/src/main/scripts/datasourceConfig-postgresql.sh
+++ b/weblogic-azure-vm/arm-oraclelinux-wls-cluster/arm-oraclelinux-wls-cluster/src/main/scripts/datasourceConfig-postgresql.sh
@@ -17,6 +17,11 @@ function usage()
 
 function validateInput()
 {
+   # parse base64 string
+   wlsPassword=$(echo "${wlsPassword}" | base64 -d)
+   jdbcDataSourceName=$(echo "${jdbcDataSourceName}" | base64 -d)
+   dsConnectionURL=$(echo "${dsConnectionURL}" | base64 -d)
+   dsPassword=$(echo "${dsPassword}" | base64 -d)
 
    if [ -z "$oracleHome" ];
    then
@@ -83,7 +88,6 @@ function validateInput()
        echo _stderr "Please provide Weblogic target cluster name"
        exit 1
    fi
-
 }
 
 function createJDBCSource_model()

--- a/weblogic-azure-vm/arm-oraclelinux-wls-cluster/arm-oraclelinux-wls-cluster/src/main/scripts/datasourceConfig-sqlserver.sh
+++ b/weblogic-azure-vm/arm-oraclelinux-wls-cluster/arm-oraclelinux-wls-cluster/src/main/scripts/datasourceConfig-sqlserver.sh
@@ -17,6 +17,11 @@ function usage()
 
 function validateInput()
 {
+   # parse base64 string
+   wlsPassword=$(echo "${wlsPassword}" | base64 -d)
+   jdbcDataSourceName=$(echo "${jdbcDataSourceName}" | base64 -d)
+   dsConnectionURL=$(echo "${dsConnectionURL}" | base64 -d)
+   dsPassword=$(echo "${dsPassword}" | base64 -d)
 
    if [ -z "$oracleHome" ];
    then
@@ -83,7 +88,6 @@ function validateInput()
        echo _stderr "Please provide Weblogic target cluster name"
        exit 1
    fi
-
 }
 
 function createJDBCSource_model()

--- a/weblogic-azure-vm/arm-oraclelinux-wls-dynamic-cluster/arm-oraclelinux-wls-dynamic-cluster/src/main/arm/nestedtemplates/dbTemplate.json
+++ b/weblogic-azure-vm/arm-oraclelinux-wls-dynamic-cluster/arm-oraclelinux-wls-dynamic-cluster/src/main/arm/nestedtemplates/dbTemplate.json
@@ -132,7 +132,7 @@
                     ]
                 },
                 "protectedSettings": {
-                     "commandToExecute": "[concat('sh',' ',variables('name_scriptFilePrefix'),parameters('databaseType'),'.sh <<< \"',variables('const_wlsHome'),' ',parameters('adminVMName'),' ',variables('const_wlsAdminPort'),' ',parameters('wlsUserName'),' ',parameters('wlsPassword'),' ',parameters('jdbcDataSourceName'),' ',parameters('dsConnectionURL'),' ',parameters('dbUser'),' ',parameters('dbPassword'),' ',parameters('dbGlobalTranPro'),'\"')]"
+                     "commandToExecute": "[concat('sh',' ',variables('name_scriptFilePrefix'),parameters('databaseType'),'.sh <<< \"',variables('const_wlsHome'),' ',parameters('adminVMName'),' ',variables('const_wlsAdminPort'),' ',parameters('wlsUserName'),' ',base64(parameters('wlsPassword')),' ',base64(parameters('jdbcDataSourceName')),' ',base64(parameters('dsConnectionURL')),' ',parameters('dbUser'),' ',base64(parameters('dbPassword')),' ',parameters('dbGlobalTranPro'),'\"')]"
                 }
             }
         },

--- a/weblogic-azure-vm/arm-oraclelinux-wls-dynamic-cluster/arm-oraclelinux-wls-dynamic-cluster/src/main/scripts/datasourceConfig-oracle.sh
+++ b/weblogic-azure-vm/arm-oraclelinux-wls-dynamic-cluster/arm-oraclelinux-wls-dynamic-cluster/src/main/scripts/datasourceConfig-oracle.sh
@@ -25,6 +25,11 @@ function usage()
 
 function validateInput()
 {
+   # parse base64 string
+   wlsPassword=$(echo "${wlsPassword}" | base64 -d)
+   jdbcDataSourceName=$(echo "${jdbcDataSourceName}" | base64 -d)
+   dsConnectionURL=$(echo "${dsConnectionURL}" | base64 -d)
+   dsPassword=$(echo "${dsPassword}" | base64 -d)
 
    if [ -z "$oracleHome" ];
    then
@@ -91,7 +96,6 @@ function validateInput()
        echo _stderr "Please provide Weblogic target cluster name"
        exit 1
    fi
-
 }
 
 function createJDBCSource_model()

--- a/weblogic-azure-vm/arm-oraclelinux-wls-dynamic-cluster/arm-oraclelinux-wls-dynamic-cluster/src/main/scripts/datasourceConfig-postgresql.sh
+++ b/weblogic-azure-vm/arm-oraclelinux-wls-dynamic-cluster/arm-oraclelinux-wls-dynamic-cluster/src/main/scripts/datasourceConfig-postgresql.sh
@@ -25,6 +25,11 @@ function usage()
 
 function validateInput()
 {
+   # parse base64 string
+   wlsPassword=$(echo "${wlsPassword}" | base64 -d)
+   jdbcDataSourceName=$(echo "${jdbcDataSourceName}" | base64 -d)
+   dsConnectionURL=$(echo "${dsConnectionURL}" | base64 -d)
+   dsPassword=$(echo "${dsPassword}" | base64 -d)
 
    if [ -z "$oracleHome" ];
    then
@@ -91,7 +96,6 @@ function validateInput()
        echo _stderr "Please provide Weblogic target cluster name"
        exit 1
    fi
-
 }
 
 function createJDBCSource_model()

--- a/weblogic-azure-vm/arm-oraclelinux-wls-dynamic-cluster/arm-oraclelinux-wls-dynamic-cluster/src/main/scripts/datasourceConfig-sqlserver.sh
+++ b/weblogic-azure-vm/arm-oraclelinux-wls-dynamic-cluster/arm-oraclelinux-wls-dynamic-cluster/src/main/scripts/datasourceConfig-sqlserver.sh
@@ -25,6 +25,11 @@ function usage()
 
 function validateInput()
 {
+   # parse base64 string
+   wlsPassword=$(echo "${wlsPassword}" | base64 -d)
+   jdbcDataSourceName=$(echo "${jdbcDataSourceName}" | base64 -d)
+   dsConnectionURL=$(echo "${dsConnectionURL}" | base64 -d)
+   dsPassword=$(echo "${dsPassword}" | base64 -d)
 
    if [ -z "$oracleHome" ];
    then
@@ -91,7 +96,6 @@ function validateInput()
        echo _stderr "Please provide Weblogic target cluster name"
        exit 1
    fi
-
 }
 
 function createJDBCSource_model()


### PR DESCRIPTION
Recently, we had a customer running into error `java.lang.IllegalArgumentException: oracle123 is not a legal value for GlobalTransactionsProtocol. The value must be one of the following: [TwoPhaseCommit, LoggingLastResource, EmulateTwoPhaseCommit, OnePhaseCommit, None]`, which possibly caused by spaces in DB connection string.

This pr is to:

- Base64 encode complicated parameters such as `wlsPassword`, `dbConnectionString`, `jdbcDataSourceName` and `dbPassword` to avoid shell arguments failure for special characters.

Test: 
- https://github.com/galiacheng/weblogic-azure/actions/runs/2751983574
- https://github.com/galiacheng/weblogic-azure/actions/runs/2751984988
- https://github.com/galiacheng/weblogic-azure/actions/runs/2751986236