### PR TITLE
Fix aks version issue

### DIFF
--- a/weblogic-azure-aks/src/main/arm/scripts/inline-scripts/validateParameters.sh
+++ b/weblogic-azure-aks/src/main/arm/scripts/inline-scripts/validateParameters.sh
@@ -447,6 +447,14 @@ function validate_dns_zone() {
   fi
 }
 
+function get_aks_default_version() {
+  constDefaultAKSVersion=$(az aks get-versions --location ${location} \
+    | jq '.orchestrators[] | select(.default==true) | .orchestratorVersion' \
+    | tr -d "\"")
+
+  validate_status "get AKS default version ${constDefaultAKSVersion}"
+}
+
 function validate_aks_version() {
   if [[ "${USE_AKS_WELL_TESTED_VERSION,,}" == "true" ]]; then
     local aksWellTestedVersionFile=aks_well_tested_version.json
@@ -462,6 +470,7 @@ function validate_aks_version() {
       outputAksVersion=${aksWellTestedVersion}
     else
       # if the well-tested version is invalid, use default version.
+      get_aks_default_version
       outputAksVersion=${constDefaultAKSVersion}
     fi
   else

--- a/weblogic-azure-aks/src/main/resources/aks_well_tested_version.json
+++ b/weblogic-azure-aks/src/main/resources/aks_well_tested_version.json
@@ -1,6 +1,6 @@
 {
     "name": "Known-good version of Azure Kubernetes Service",
     "description": "This version is known to work for all the features of Azure WebLogic on AKS offer.",
-    "value": "1.21.9",
-    "testedDate": "2022-05-09"
+    "value": "1.24.3",
+    "testedDate": "2022-08-24"
 }


### PR DESCRIPTION
Fix error "error parsing version(default) as semver: Invalid Semantic Version". We have to pass a semantic version to create AKS.