### PR TITLE
Support MySQL in WLS on VM configured cluster

### DIFF
--- a/weblogic-azure-vm/arm-oraclelinux-wls-cluster/arm-oraclelinux-wls-cluster/pom.xml
+++ b/weblogic-azure-vm/arm-oraclelinux-wls-cluster/arm-oraclelinux-wls-cluster/pom.xml
@@ -12,7 +12,7 @@
 
     <groupId>com.oracle.weblogic.azure</groupId>
     <artifactId>arm-oraclelinux-wls-cluster</artifactId>
-    <version>1.0.46000</version>
+    <version>1.0.47000</version>
     
     <parent>
         <groupId>com.microsoft.azure.iaas</groupId>

--- a/weblogic-azure-vm/arm-oraclelinux-wls-cluster/arm-oraclelinux-wls-cluster/src/main/arm/createUiDefinition.json
+++ b/weblogic-azure-vm/arm-oraclelinux-wls-cluster/arm-oraclelinux-wls-cluster/src/main/arm/createUiDefinition.json
@@ -1391,7 +1391,7 @@
                                 "visible": "[and(equals(steps('section_database').databaseConnectionInfo.databaseType, 'mysql'), or(equals(basics('skuUrnVersion'), 'owls-122130-jdk8-ol74;Oracle:weblogic-122130-jdk8-ol74:owls-122130-jdk8-ol7;latest'), equals(basics('skuUrnVersion'), 'owls-122130-jdk8-ol73;Oracle:weblogic-122130-jdk8-ol73:owls-122130-jdk8-ol7;latest')))]",
                                 "options": {
                                     "icon": "Warning",
-                                    "text": "Your current selection of WebLogic Server version, Java version, and MySQL database has a known problem. Please see the link for important information on how to solve it.",
+                                    "text": "Your current selection of WebLogic Server version, Java version, and MySQL uses a problematic JDBC driver. Consult the certification matrix at https://aka.ms/wls-vms-12213-certification-matrix and use the instructions in the the link below to replace the JDBC driver with the correct version after deployment.",
                                     "uri": "https://aka.ms/wls-vms-mysql-12213"
                                 }
                             },
@@ -1423,7 +1423,7 @@
                                         },
                                         {
                                             "isValid": "[if(equals(steps('section_database').databaseConnectionInfo.databaseType, 'mysql'), and(contains(steps('section_database').databaseConnectionInfo.dsConnectionURL,'serverTimezone'), contains(steps('section_database').databaseConnectionInfo.dsConnectionURL,'enabledTLSProtocols=TLSv1.2')), bool('true'))]",
-                                            "message": "The connection string of MySQL must contain server time zone and enable TLS v1.2, for an example, 'jdbc:mysql://contoso.mysql.database.azure.com:3306/guest?useSSL=true&requireSSL=false&serverTimezone=UTC&enabledTLSProtocols=TLSv1.2'."
+                                            "message": "When using MySQL, the connection string must contain server time zone and enable TLS v1.2. For example, see the last two query parameters here: 'jdbc:mysql://contoso.mysql.database.azure.com:3306/guest?useSSL=true&requireSSL=false&serverTimezone=UTC&enabledTLSProtocols=TLSv1.2'."
                                         }
                                     ]
                                 },

--- a/weblogic-azure-vm/arm-oraclelinux-wls-cluster/arm-oraclelinux-wls-cluster/src/main/arm/createUiDefinition.json
+++ b/weblogic-azure-vm/arm-oraclelinux-wls-cluster/arm-oraclelinux-wls-cluster/src/main/arm/createUiDefinition.json
@@ -1386,6 +1386,16 @@
                                 "visible": true
                             },
                             {
+                                "name": "dbDriverWarningInfo",
+                                "type": "Microsoft.Common.InfoBox",
+                                "visible": "[and(equals(steps('section_database').databaseConnectionInfo.databaseType, 'mysql'), or(equals(basics('skuUrnVersion'), 'owls-122130-jdk8-ol74;Oracle:weblogic-122130-jdk8-ol74:owls-122130-jdk8-ol7;latest'), equals(basics('skuUrnVersion'), 'owls-122130-jdk8-ol73;Oracle:weblogic-122130-jdk8-ol73:owls-122130-jdk8-ol7;latest')))]",
+                                "options": {
+                                    "icon": "Warning",
+                                    "text": "Your current selection of WebLogic Server version, Java version, and MySQL database has a known problem. Please see the link for important information on how to solve it.",
+                                    "uri": "https://aka.ms/wls-vms-mysql-12213"
+                                }
+                            },
+                            {
                                 "name": "jdbcDataSourceName",
                                 "type": "Microsoft.Common.TextBox",
                                 "label": "JNDI Name",

--- a/weblogic-azure-vm/arm-oraclelinux-wls-cluster/arm-oraclelinux-wls-cluster/src/main/arm/createUiDefinition.json
+++ b/weblogic-azure-vm/arm-oraclelinux-wls-cluster/arm-oraclelinux-wls-cluster/src/main/arm/createUiDefinition.json
@@ -1375,6 +1375,10 @@
                                         {
                                             "label": "Azure SQL",
                                             "value": "sqlserver"
+                                        },
+                                        {
+                                            "label": "MySQL",
+                                            "value": "mysql"
                                         }
                                     ],
                                     "required": true
@@ -1402,8 +1406,16 @@
                                 "defaultValue": "",
                                 "constraints": {
                                     "required": "[bool(steps('section_database').enableDB)]",
-                                    "regex": "[concat('^jdbc:', coalesce(steps('section_database').databaseConnectionInfo.databaseType, ''), '.*$')]",
-                                    "validationMessage": "A valid JDBC URL for the chosen database type must be provided"
+									"validations": [
+                                        {
+                                            "regex": "[concat('^jdbc:', coalesce(steps('section_database').databaseConnectionInfo.databaseType, ''), '.*$')]",
+                                            "message": "A valid JDBC URL for the chosen database type must be provided"
+                                        },
+                                        {
+                                            "isValid": "[if(equals(steps('section_database').databaseConnectionInfo.databaseType, 'mysql'), and(contains(steps('section_database').databaseConnectionInfo.dsConnectionURL,'serverTimezone'), contains(steps('section_database').databaseConnectionInfo.dsConnectionURL,'enabledTLSProtocols=TLSv1.2')), bool('true'))]",
+                                            "message": "The connection string of MySQL must contain server time zone and enable TLS v1.2, for an example, 'jdbc:mysql://contoso.mysql.database.azure.com:3306/guest?useSSL=true&requireSSL=false&serverTimezone=UTC&enabledTLSProtocols=TLSv1.2'."
+                                        }
+                                    ]
                                 },
                                 "visible": true
                             },

--- a/weblogic-azure-vm/arm-oraclelinux-wls-cluster/arm-oraclelinux-wls-cluster/src/main/arm/nestedtemplates/dbTemplate.json
+++ b/weblogic-azure-vm/arm-oraclelinux-wls-cluster/arm-oraclelinux-wls-cluster/src/main/arm/nestedtemplates/dbTemplate.json
@@ -96,7 +96,8 @@
         "name_scriptFilePrefix": "datasourceConfig-",
         "name_scriptFileSuffix-sqlserver": "sqlserver.sh",
         "name_scriptFileSuffix-oracle": "oracle.sh",
-        "name_scriptFileSuffix-postgresql": "postgresql.sh"
+        "name_scriptFileSuffix-postgresql": "postgresql.sh",
+        "name_scriptFileSuffix-mysql": "mysql.sh"
     },
     "resources": [
         {
@@ -127,7 +128,8 @@
                     "fileUris": [
                         "[uri(parameters('_artifactsLocationDbTemplate'), concat('../scripts/', variables('name_scriptFilePrefix'), variables('name_scriptFileSuffix-sqlserver'), parameters('_artifactsLocationSasToken')))]",
                         "[uri(parameters('_artifactsLocationDbTemplate'), concat('../scripts/', variables('name_scriptFilePrefix'), variables('name_scriptFileSuffix-oracle'), parameters('_artifactsLocationSasToken')))]",
-                        "[uri(parameters('_artifactsLocationDbTemplate'), concat('../scripts/', variables('name_scriptFilePrefix'), variables('name_scriptFileSuffix-postgresql'), parameters('_artifactsLocationSasToken')))]"
+                        "[uri(parameters('_artifactsLocationDbTemplate'), concat('../scripts/', variables('name_scriptFilePrefix'), variables('name_scriptFileSuffix-postgresql'), parameters('_artifactsLocationSasToken')))]",
+                        "[uri(parameters('_artifactsLocationDbTemplate'), concat('../scripts/', variables('name_scriptFilePrefix'), variables('name_scriptFileSuffix-mysql'), parameters('_artifactsLocationSasToken')))]"
                     ]
                 },
                 "protectedSettings": {
@@ -175,6 +177,24 @@
             "apiVersion": "${azure.apiVersion}",
             "name": "${database.postgresql}",
             "condition": "[if(contains(parameters('databaseType'), 'postgresql'), bool('true'), bool('false'))]",
+            "dependsOn": [
+                "[resourceId('Microsoft.Compute/virtualMachines/extensions', parameters('adminVMName'), 'newuserscript')]"
+            ],
+            "properties": {
+                "mode": "Incremental",
+                "template": {
+                    "$schema": "https://schema.management.azure.com/schemas/2015-01-01/deploymentTemplate.json#",
+                    "contentVersion": "1.0.0.0",
+                    "resources": [
+                    ]
+                }
+            }
+        },
+        {
+            "type": "Microsoft.Resources/deployments",
+            "apiVersion": "${azure.apiVersion}",
+            "name": "${database.mysql}",
+            "condition": "[if(contains(parameters('databaseType'), 'mysql'), bool('true'), bool('false'))]",
             "dependsOn": [
                 "[resourceId('Microsoft.Compute/virtualMachines/extensions', parameters('adminVMName'), 'newuserscript')]"
             ],

--- a/weblogic-azure-vm/arm-oraclelinux-wls-cluster/arm-oraclelinux-wls-cluster/src/main/scripts/datasourceConfig-mysql.sh
+++ b/weblogic-azure-vm/arm-oraclelinux-wls-cluster/arm-oraclelinux-wls-cluster/src/main/scripts/datasourceConfig-mysql.sh
@@ -1,0 +1,177 @@
+# Copyright (c) 2021, Oracle and/or its affiliates.
+# Licensed under the Universal Permissive License v 1.0 as shown at https://oss.oracle.com/licenses/upl.
+# Description
+# This script is to configure datasource at WebLogic cluster domain.
+
+#Function to output message to StdErr
+function echo_stderr ()
+{
+    echo "$@" >&2
+}
+
+#Function to display usage message
+function usage()
+{
+  echo_stderr "./configDatasource.sh <<< \"<dataSourceConfigArgumentsFromStdIn>\""
+}
+
+function validateInput()
+{
+   # parse base64 string
+   wlsPassword=$(echo "${wlsPassword}" | base64 -d)
+   jdbcDataSourceName=$(echo "${jdbcDataSourceName}" | base64 -d)
+   dsConnectionURL=$(echo "${dsConnectionURL}" | base64 -d)
+   dsPassword=$(echo "${dsPassword}" | base64 -d)
+
+   if [ -z "$oracleHome" ];
+   then
+       echo _stderr "Please provide oracleHome"
+       exit 1
+   fi
+
+   if [ -z "$wlsAdminHost" ];
+   then
+       echo _stderr "Please provide WeblogicServer hostname"
+       exit 1
+   fi
+
+   if [ -z "$wlsAdminPort" ];
+   then
+       echo _stderr "Please provide Weblogic admin port"
+       exit 1
+   fi
+
+   if [ -z "$wlsUserName" ];
+   then
+       echo _stderr "Please provide Weblogic username"
+       exit 1
+   fi
+
+   if [ -z "$wlsPassword" ];
+   then
+       echo _stderr "Please provide Weblogic password"
+       exit 1
+   fi
+
+   if [ -z "$jdbcDataSourceName" ];
+   then
+       echo _stderr "Please provide JDBC datasource name to be configured"
+       exit 1
+   fi
+
+   if [ -z "$dsConnectionURL" ];
+   then
+        echo _stderr "Please provide Azure database of MySQL URL in the format 'jdbc:oracle:thin:@<db host name>:<db port>/<database name>'"
+        exit 1
+   fi
+
+   if [ -z "$dsUser" ];
+   then
+       echo _stderr "Please provide Azure database of MySQL user name"
+       exit 1
+   fi
+
+   if [ -z "$dsPassword" ];
+   then
+       echo _stderr "Please provide Azure database of MySQL password"
+       exit 1
+   fi
+
+   if [ -z "$dbGlobalTranPro" ];
+   then
+       echo _stderr "Please provide Global transactions protocol"
+       exit 1
+   fi
+
+   if [ -z "$wlsClusterName" ];
+   then
+       echo _stderr "Please provide Weblogic target cluster name"
+       exit 1
+   fi
+}
+
+function createJDBCSource_model()
+{
+echo "Creating JDBC data source with name $jdbcDataSourceName"
+cat <<EOF >${scriptPath}/create_datasource.py
+connect('$wlsUserName','$wlsPassword','t3://$wlsAdminURL')
+edit("$hostName")
+startEdit()
+cd('/')
+try:
+  cmo.createJDBCSystemResource('$jdbcDataSourceName')
+  cd('/JDBCSystemResources/$jdbcDataSourceName/JDBCResource/$jdbcDataSourceName')
+  cmo.setName('$jdbcDataSourceName')
+  cd('/JDBCSystemResources/$jdbcDataSourceName/JDBCResource/$jdbcDataSourceName/JDBCDataSourceParams/$jdbcDataSourceName')
+  set('JNDINames',jarray.array([String('$jdbcDataSourceName')], String))
+  cd('/JDBCSystemResources/$jdbcDataSourceName/JDBCResource/$jdbcDataSourceName')
+  cmo.setDatasourceType('GENERIC')
+  cd('/JDBCSystemResources/$jdbcDataSourceName/JDBCResource/$jdbcDataSourceName/JDBCDriverParams/$jdbcDataSourceName')
+  cmo.setUrl('$dsConnectionURL')
+  cmo.setDriverName('com.mysql.jdbc.Driver')
+  cmo.setPassword('$dsPassword')
+  cd('/JDBCSystemResources/$jdbcDataSourceName/JDBCResource/$jdbcDataSourceName/JDBCConnectionPoolParams/$jdbcDataSourceName')
+  cmo.setTestTableName('SQL ISVALID\r\n\r\n\r\n\r\n')
+  cd('/JDBCSystemResources/$jdbcDataSourceName/JDBCResource/$jdbcDataSourceName/JDBCDriverParams/$jdbcDataSourceName/Properties/$jdbcDataSourceName')
+  cmo.createProperty('user')
+  cd('/JDBCSystemResources/$jdbcDataSourceName/JDBCResource/$jdbcDataSourceName/JDBCDriverParams/$jdbcDataSourceName/Properties/$jdbcDataSourceName/Properties/user')
+  cmo.setValue('$dsUser')
+  cd('/JDBCSystemResources/$jdbcDataSourceName/JDBCResource/$jdbcDataSourceName/JDBCDataSourceParams/$jdbcDataSourceName')
+  cmo.setGlobalTransactionsProtocol('${dbGlobalTranPro}')
+  cd('/JDBCSystemResources/$jdbcDataSourceName')
+  set('Targets',jarray.array([ObjectName('com.bea:Name=$wlsClusterName,Type=Cluster')], ObjectName))
+  save()
+  resolve()
+  activate()
+except Exception, e:
+  e.printStackTrace()
+  dumpStack()
+  undo('true',defaultAnswer='y')
+  cancelEdit('y')
+  destroyEditSession("$hostName",force = true)
+  raise("$jdbcDataSourceName configuration failed")
+destroyEditSession("$hostName",force = true)
+disconnect()
+EOF
+}
+
+function createTempFolder()
+{
+    scriptPath="/u01/tmp"
+    sudo rm -f -r ${scriptPath}
+    sudo mkdir ${scriptPath}
+    sudo rm -rf $scriptPath/*
+}
+
+#main
+
+#read arguments from stdin
+read oracleHome wlsAdminHost wlsAdminPort wlsUserName wlsPassword jdbcDataSourceName dsConnectionURL dsUser dsPassword dbGlobalTranPro wlsClusterName
+
+if [ -z "$wlsClusterName" ];
+then
+   wlsClusterName="cluster1"
+fi
+
+wlsAdminURL=$wlsAdminHost:$wlsAdminPort
+hostName=`hostname`
+
+
+createTempFolder
+validateInput
+createJDBCSource_model
+
+sudo chown -R oracle:oracle ${scriptPath}
+runuser -l oracle -c ". $oracleHome/oracle_common/common/bin/setWlstEnv.sh; java $WLST_ARGS weblogic.WLST  ${scriptPath}/create_datasource.py"
+
+errorCode=$?
+if [ $errorCode -eq 1 ]
+then 
+    echo "Exception occurs during DB configuration, please check."
+    exit 1
+fi
+
+echo "Cleaning up temporary files..."
+rm -f -r ${scriptPath}
+
+

--- a/weblogic-azure-vm/arm-oraclelinux-wls/src/main/resources/microsoft-pid.properties
+++ b/weblogic-azure-vm/arm-oraclelinux-wls/src/main/resources/microsoft-pid.properties
@@ -68,6 +68,7 @@ cluster.start=ca5e3350-ff62-5d92-83a3-acaaeae87c03
 database.oracle=692b2d84-72f5-5992-a15d-0d5bcfef040d
 database.postgresql=935df06e-a5d5-5bf1-af66-4c1eb71dac7a
 database.sqlserver=3569588c-b89d-5567-84ee-a2c633c7204c
+database.mysql=de95ae02-f841-4c48-a69e-4bf09c4271bb
 
 # Pids used in https://github.com/oracle/weblogic-azure/tree/main/weblogic-azure-vm/arm-oraclelinux-wls-dynamic-cluster
 

--- a/weblogic-azure-vm/arm-oraclelinux-wls/src/main/resources/pid.properties
+++ b/weblogic-azure-vm/arm-oraclelinux-wls/src/main/resources/pid.properties
@@ -67,6 +67,7 @@ cluster.start=pid-7363cd91-937d-4469-a7a8-ecbeddfb7a0f-partnercenter
 database.oracle=692b2d84-72f5-5992-a15d-0d5bcfef040d
 database.postgresql=935df06e-a5d5-5bf1-af66-4c1eb71dac7a
 database.sqlserver=3569588c-b89d-5567-84ee-a2c633c7204c
+database.mysql=41c353ae-6f7b-442f-b903-996cb42c1bbe
 
 # Pids used in https://github.com/oracle/weblogic-azure/tree/main/weblogic-azure-vm/arm-oraclelinux-wls-dynamic-cluster
 


### PR DESCRIPTION
## Change
* Add MySQL support in UX. 
![image](https://user-images.githubusercontent.com/74032668/186839689-34bc2095-1f17-4281-bd05-1ab1f3d54c0f.png)
Currently MySQL driver in WebLogic Server 12.2.1.3.0 is too old to support this feature, if users decide to move forward with images:
    * WebLogic Server 12.2.1.3.0 and JDK8 on Oracle Linux 7.4
    * WebLogic Server 12.2.1.3.0 and JDK8 on Oracle Linux 7.3
We will pop up a warning info like below:
![image](https://user-images.githubusercontent.com/74032668/186840285-508bc29b-c06c-46a8-88c3-68d999e4ebc2.png)
**Users can still proceed, and the deployment will fail.**
Full error message starts with:
```
Stack trace for message 149004 weblogic.application.ModuleException: javax.net.ssl.SSLHandshakeException: No appropriate protocol (protocol is disabled or cipher suites are inappropriate) at
weblogic.jdbc.module.JDBCModule.prepare(JDBCModule.java:408) at
weblogic.application.internal.flow.ModuleListenerInvoker.prepare(ModuleListenerInvoker.java:100) at
weblogic.application.internal.flow.ModuleStateDriver$1.next(ModuleStateDriver.java:192) at
weblogic.application.internal.flow.ModuleStateDriver$1.next(ModuleStateDriver.java:187) at...
```

## Test
Pipeline: [Test Configured Cluster on VM](https://github.com/zhengchang907/weblogic-azure/actions/runs/2931886689)
Preview offer:
* WLS 12.2.1.3 JDK8 Oracle Linux 7. 3
* WLS 14.1.1.0 JDK11 Oracle Linux 7. 6
* WLS 14.1.1.0 JDK11 RHEL 7. 6


 