### PR TITLE
Fix typo in WLS on VM Admin Offer: Remove extra server word from ELK …

### DIFF
--- a/weblogic-azure-vm/arm-oraclelinux-wls-admin/src/main/arm/createUiDefinition.json
+++ b/weblogic-azure-vm/arm-oraclelinux-wls-admin/src/main/arm/createUiDefinition.json
@@ -1309,7 +1309,7 @@
                     {
                         "name": "enableELK",
                         "type": "Microsoft.Common.OptionsGroup",
-                        "label": "Export logs to Elasticsearch server?",
+                        "label": "Export logs to Elasticsearch?",
                         "defaultValue": "No",
                         "toolTip": "Select 'Yes' and provide required info to configure the connection to Elasticsearch.",
                         "constraints": {


### PR DESCRIPTION
In the admin offer, the sentence is mentioned as "Export logs to Elasticsearch server?", whereas in the cluster and dynamic cluster offer, it is mentioned as "Export logs to Elasticsearch?".