### PR TITLE
Revert changes for VM Size parameter naming

### DIFF
--- a/weblogic-azure-aks/src/main/arm/createUiDefinition.json
+++ b/weblogic-azure-aks/src/main/arm/createUiDefinition.json
@@ -2174,7 +2174,7 @@
             "validateApplications": "[bool(steps('section_aks').jeeAppInfo.validateApplications)]",
             "vnetForApplicationGateway": "[steps('section_appGateway').appgwIngress.vnetForApplicationGateway]",
             "vnetRGNameForApplicationGateway": "[steps('section_appGateway').appgwIngress.vnetForApplicationGateway.resourceGroup]",
-            "vmSize": "[steps('section_aks').clusterInfo.nodeVMSizeSelector]",
+            "aksAgentPoolVMSize": "[steps('section_aks').clusterInfo.nodeVMSizeSelector]",
             "wdtRuntimePassword": "[basics('basicsRequired').wdtRuntimePassword]",
             "wlsClusterSize": "[basics('basicsOptional').wlsClusterSize]",
             "wlsDomainName": "[basics('basicsOptional').wlsDomainName]",

--- a/weblogic-azure-aks/src/main/bicep/mainTemplate.bicep
+++ b/weblogic-azure-aks/src/main/bicep/mainTemplate.bicep
@@ -38,7 +38,7 @@ param aksAgentPoolName string = 'agentpool'
 @description('The number of nodes that should be created along with the cluster. You will be able to resize the cluster later.')
 param aksAgentPoolNodeCount int = 3
 @description('The size of the virtual machines that will form the nodes in the cluster. This cannot be changed after creating the cluster')
-param vmSize string = 'Standard_DS2_v2'
+param aksAgentPoolVMSize string = 'Standard_DS2_v2'
 @description('Prefix for cluster name. Only The name can contain only letters, numbers, underscores and hyphens. The name must start with letter or number.')
 param aksClusterNamePrefix string = 'wlsonaks'
 @description('Resource group name of an existing AKS cluster.')
@@ -380,7 +380,7 @@ module validateInputs 'modules/_deployment-scripts/_ds-validate-parameters.bicep
   params: {
     acrName: preAzureResourceDeployment.outputs.acrName
     aksAgentPoolNodeCount: aksAgentPoolNodeCount
-    aksAgentPoolVMSize: vmSize
+    aksAgentPoolVMSize: aksAgentPoolVMSize
     aksClusterRGName: aksClusterRGName
     aksClusterName: aksClusterName
     aksVersion: aksVersion
@@ -541,7 +541,7 @@ module wlsDomainDeployment 'modules/setupWebLogicCluster.bicep' = if (!enableCus
     acrName: preAzureResourceDeployment.outputs.acrName
     aksAgentPoolName: aksAgentPoolName
     aksAgentPoolNodeCount: aksAgentPoolNodeCount
-    vmSize: vmSize
+    aksAgentPoolVMSize: aksAgentPoolVMSize
     aksClusterNamePrefix: aksClusterNamePrefix
     aksClusterRGName: aksClusterRGName
     aksClusterName: aksClusterName
@@ -607,7 +607,7 @@ module wlsDomainWithCustomSSLDeployment 'modules/setupWebLogicCluster.bicep' = i
     acrName: preAzureResourceDeployment.outputs.acrName
     aksAgentPoolName: aksAgentPoolName
     aksAgentPoolNodeCount: aksAgentPoolNodeCount
-    vmSize: vmSize
+    aksAgentPoolVMSize: aksAgentPoolVMSize
     aksClusterNamePrefix: aksClusterNamePrefix
     aksClusterRGName: aksClusterRGName
     aksClusterName: aksClusterName

--- a/weblogic-azure-aks/src/main/bicep/modules/_azure-resoruces/_aks.bicep
+++ b/weblogic-azure-aks/src/main/bicep/modules/_azure-resoruces/_aks.bicep
@@ -16,7 +16,7 @@ param aksAgentPoolName string = 'agentpool'
 @description('The number of nodes that should be created along with the cluster. You will be able to resize the cluster later.')
 param aksAgentPoolNodeCount int = 3
 @description('The size of the virtual machines that will form the nodes in the cluster. This cannot be changed after creating the cluster')
-param vmSize string = 'Standard_DS2_v2'
+param aksAgentPoolVMSize string = 'Standard_DS2_v2'
 @description('Prefix for cluster name. Only The name can contain only letters, numbers, underscores and hyphens. The name must start with letter or number.')
 param aksClusterNamePrefix string = 'wlsonaks'
 param aksVersion string = 'default'
@@ -71,7 +71,7 @@ resource aksCluster 'Microsoft.ContainerService/managedClusters@2021-02-01' = {
       {
         name: aksAgentPoolName
         count: aksAgentPoolNodeCount
-        vmSize: vmSize
+        aksAgentPoolVMSize: aksAgentPoolVMSize
         osDiskSizeGB: const_aksAgentPoolOSDiskSizeGB
         osDiskType: 'Managed'
         kubeletDiskType: 'OS'

--- a/weblogic-azure-aks/src/main/bicep/modules/_deployment-scripts/_ds-validate-parameters.bicep
+++ b/weblogic-azure-aks/src/main/bicep/modules/_deployment-scripts/_ds-validate-parameters.bicep
@@ -3,7 +3,7 @@
 
 param acrName string
 param aksAgentPoolNodeCount int
-param aksAgentPoolVMSize string
+param aksAgentPoolVMSize string = 'Standard_DS2_v2'
 param aksClusterRGName string
 param aksClusterName string
 param aksVersion string = 'default'

--- a/weblogic-azure-aks/src/main/bicep/modules/setupWebLogicCluster.bicep
+++ b/weblogic-azure-aks/src/main/bicep/modules/setupWebLogicCluster.bicep
@@ -35,7 +35,7 @@ param aksAgentPoolName string = 'agentpool'
 @description('The number of nodes that should be created along with the cluster. You will be able to resize the cluster later.')
 param aksAgentPoolNodeCount int = 3
 @description('The size of the virtual machines that will form the nodes in the cluster. This cannot be changed after creating the cluster')
-param vmSize string = 'Standard_DS2_v2'
+param aksAgentPoolVMSize string = 'Standard_DS2_v2'
 @description('Prefix for cluster name. Only The name can contain only letters, numbers, underscores and hyphens. The name must start with letter or number.')
 param aksClusterNamePrefix string = 'wlsonaks'
 @description('Resource group name of an existing AKS cluster.')
@@ -140,7 +140,7 @@ module aksClusterDeployment './_azure-resoruces/_aks.bicep' = if (createAKSClust
     aciWorkspaceSku: aciWorkspaceSku
     aksAgentPoolName: aksAgentPoolName
     aksAgentPoolNodeCount: aksAgentPoolNodeCount
-    vmSize: vmSize
+    aksAgentPoolVMSize: aksAgentPoolVMSize
     aksClusterNamePrefix: aksClusterNamePrefix
     aksVersion: aksVersion
     enableAzureMonitoring: enableAzureMonitoring


### PR DESCRIPTION
We have confirmed that the recent arm-ttk complaint `VMSize parameter must be declared for the parent template` is a regression, see https://github.com/Azure/arm-ttk/issues/695.

As `vmSize` caused offer certification failure in partner center, this PR is to revert the change.
 
Changes:
- Revert change for vmSize naming.
- Set default value to aksAgentPoolVMSize.

No doc change needed.

Signed-off-by: galiacheng <haixia.cheng@microsoft.com>