### PR TITLE
Added PIDs for OL8.7 and 9.1 base images

### DIFF
--- a/weblogic-azure-vm/arm-oraclelinux-wls/src/main/resources/microsoft-pid.properties
+++ b/weblogic-azure-vm/arm-oraclelinux-wls/src/main/resources/microsoft-pid.properties
@@ -124,6 +124,13 @@ from.owls-122130-jdk8-ol73=bf1d0f1a-cb9a-5453-bf70-42b4efe8c15e
 from.owls-122140-jdk8-ol76=bde756bb-ce96-54d5-a478-04d9bd87e9db
 from.owls-141100-jdk8-ol76=b6f00a34-1478-5a10-9a84-49c4051b57b8
 from.owls-141100-jdk11-ol76=afc8f9c5-8c5d-5d1b-ab4d-3116ca908bfd
+from.owls-122140-jdk8-ol87=cc7ee628-3750-489c-97f5-1e484d710e69
+from.owls-122140-jdk8-ol91=92f40d92-0786-4812-8918-a6f9dcc1b4ec
+from.owls-141100-jdk8-ol87=5d011fae-34c1-4004-bd19-c2d2bccd30a4
+from.owls-141100-jdk8-ol91=9d76fbe1-3bbc-4a2b-a209-7427ad1db4ab
+from.owls-141100-jdk11-ol87=459c178d-aec6-4bb5-8e80-66291f0ee6a8
+from.owls-141100-jdk11-ol91=5ce9afe5-c458-41b6-9b46-4899cde11806
+
 
 # Pids to indicate which latest base image was chosen.  No difference in these
 # between Oracle and Microsoft

--- a/weblogic-azure-vm/arm-oraclelinux-wls/src/main/resources/pid.properties
+++ b/weblogic-azure-vm/arm-oraclelinux-wls/src/main/resources/pid.properties
@@ -124,6 +124,12 @@ from.owls-122130-jdk8-ol73=799fc764-af80-45c3-aea1-599f55901e73
 from.owls-122140-jdk8-ol76=6637154a-06d2-4ac0-82ab-2a1d7e391eab
 from.owls-141100-jdk8-ol76=060d9c3f-cc20-4380-a383-fd20594e5b2a
 from.owls-141100-jdk11-ol76=3220431f-33d4-416a-8df7-a0fcc23a25e4
+from.owls-122140-jdk8-ol87=f2ae4133-abd1-4711-ae74-aeb6e498f2c0
+from.owls-122140-jdk8-ol91=2b7d87a9-981a-44af-bf71-b2b479841ed9
+from.owls-141100-jdk8-ol87=d58854b4-a612-4fbf-b095-f2d2178a88df
+from.owls-141100-jdk8-ol91=76d4dbe8-0679-4772-ad2e-461fac83dfd7
+from.owls-141100-jdk11-ol87=c8f1b07d-1660-4f6a-be97-3925645e8817
+from.owls-141100-jdk11-ol91=cd48f178-52a3-415e-88bb-caa45f615b94
 
 # Pids to indicate which latest base image was chosen.  No difference in these
 # between Oracle and Microsoft


### PR DESCRIPTION
PIDs are added as per latest Oracle Linux 8.7 and 9.1 base images are published to live.