### PR TITLE
UI-Change: Update datatype to make it consistent with JBoss and WebSphere

### DIFF
--- a/weblogic-azure-aks/src/main/arm/createUiDefinition.json
+++ b/weblogic-azure-aks/src/main/arm/createUiDefinition.json
@@ -1853,7 +1853,7 @@
                                 "constraints": {
                                     "allowedValues": [
                                         {
-                                            "label": "Azure database for PostgreSQL (with support for passwordless connection)",
+                                            "label": "PostgreSQL (Support passwordless connection)",
                                             "value": "postgresql"
                                         },
                                         {
@@ -1861,11 +1861,11 @@
                                             "value": "oracle"
                                         },
                                         {
-                                            "label": "Azure SQL (with support for passwordless connection)",
+                                            "label": "Microsoft SQL Server (Support passwordless connection)",
                                             "value": "sqlserver"
                                         },
                                         {
-                                            "label": "MySQL (with support for passwordless connection)",
+                                            "label": "MySQL (Support passwordless connection)",
                                             "value": "mysql"
                                         },
                                         {

--- a/weblogic-azure-vm/arm-oraclelinux-wls-admin/src/main/arm/createUiDefinition.json
+++ b/weblogic-azure-vm/arm-oraclelinux-wls-admin/src/main/arm/createUiDefinition.json
@@ -1002,7 +1002,7 @@
                                 "constraints": {
                                     "allowedValues": [
                                         {
-                                            "label": "Azure database for PostgreSQL (with support for passwordless connection)",
+                                            "label": "PostgreSQL (Support passwordless connection)",
                                             "value": "postgresql"
                                         },
                                         {
@@ -1010,11 +1010,11 @@
                                             "value": "oracle"
                                         },
                                         {
-                                            "label": "Azure SQL (with support for passwordless connection)",
+                                            "label": "Microsoft SQL Server (Support passwordless connection)",
                                             "value": "sqlserver"
                                         },
                                         {
-                                            "label": "MySQL (with support for passwordless connection)",
+                                            "label": "MySQL (Support passwordless connection)",
                                             "value": "mysql"
                                         }
                                     ],

--- a/weblogic-azure-vm/arm-oraclelinux-wls-cluster/arm-oraclelinux-wls-cluster/src/main/arm/createUiDefinition.json
+++ b/weblogic-azure-vm/arm-oraclelinux-wls-cluster/arm-oraclelinux-wls-cluster/src/main/arm/createUiDefinition.json
@@ -1331,7 +1331,7 @@
                                 "constraints": {
                                     "allowedValues": [
                                         {
-                                            "label": "Azure database for PostgreSQL (with support for passwordless connection)",
+                                            "label": "PostgreSQL (Support passwordless connection)",
                                             "value": "postgresql"
                                         },
                                         {
@@ -1339,11 +1339,11 @@
                                             "value": "oracle"
                                         },
                                         {
-                                            "label": "Azure SQL (with support for passwordless connection)",
+                                            "label": "Microsoft SQL Server (Support passwordless connection)",
                                             "value": "sqlserver"
                                         },
                                         {
-                                            "label": "MySQL (with support for passwordless connection)",
+                                            "label": "MySQL (Support passwordless connection)",
                                             "value": "mysql"
                                         }
                                     ],

--- a/weblogic-azure-vm/arm-oraclelinux-wls-dynamic-cluster/arm-oraclelinux-wls-dynamic-cluster/src/main/arm/createUiDefinition.json
+++ b/weblogic-azure-vm/arm-oraclelinux-wls-dynamic-cluster/arm-oraclelinux-wls-dynamic-cluster/src/main/arm/createUiDefinition.json
@@ -1425,7 +1425,7 @@
                                 "constraints": {
                                     "allowedValues": [
                                         {
-                                            "label": "Azure database for PostgreSQL (with support for passwordless connection)",
+                                            "label": "PostgreSQL (Support passwordless connection)",
                                             "value": "postgresql"
                                         },
                                         {
@@ -1433,11 +1433,11 @@
                                             "value": "oracle"
                                         },
                                         {
-                                            "label": "Azure SQL (with support for passwordless connection)",
+                                            "label": "Microsoft SQL Server (Support passwordless connection)",
                                             "value": "sqlserver"
                                         },
                                         {
-                                            "label": "MySQL (with support for passwordless connection)",
+                                            "label": "MySQL (Support passwordless connection)",
                                             "value": "mysql"
                                         }
                                     ],


### PR DESCRIPTION
## Context
The database type options in the solution are inconsistent with what're in JBoss and WebSphere.  The options should focus on database brand type, so that to remove confusion.

https://aka.ms/wls-vm-cluster 
![image](https://github.com/oracle/weblogic-azure/assets/4465723/3deadbac-fa97-43aa-bb72-369ae2084d98)


## Follow-up task
- [ ] The sentences and images in this javaee passwordless ⁠[Configure passwordless database connections for Java apps on Oracle WebLogic Servers](https://learn.microsoft.com/en-us/azure/developer/java/ee/how-to-configure-passwordless-datasource?tabs=mysql-flexible-server) also need change.