### PR TITLE
Update pipelines

### DIFF
--- a/.github/actions/setupmaven/action.yml
+++ b/.github/actions/setupmaven/action.yml
@@ -1,0 +1,24 @@
+name: Set Up Maven
+description: Set up Maven with github token.
+inputs:
+  token:
+    description: "GitHub token"
+    required: true
+runs:
+  using: "composite"
+  steps:
+    - name: Set up Apache Maven and JDK
+      uses: actions/setup-java@v1
+      with:
+        java-version: 1.8
+        server-id: github # Value of the distributionManagement/repository/id field of the pom.xml
+        server-username: MAVEN_USERNAME # env variable for username
+        server-password: MAVEN_TOKEN # env variable for token
+    - name: Set Maven env
+      env:
+        MAVEN_USERNAME: github
+        MAVEN_TOKEN: ${{ inputs.token }}
+      shell: bash
+      run: |
+        echo "MAVEN_USERNAME=${MAVEN_USERNAME}" >> $GITHUB_ENV
+        echo "MAVEN_TOKEN=${MAVEN_TOKEN}" >> $GITHUB_ENV

--- a/.github/workflows/buildWlsAksArtifact.yml
+++ b/.github/workflows/buildWlsAksArtifact.yml
@@ -28,6 +28,11 @@ jobs:
                 chmod +x ./bicep
                 sudo mv ./bicep /usr/local/bin/bicep
                 bicep --version
+            - uses: actions/checkout@v2.3.4
+            - name: Set up Maven with GitHub token
+              uses: ./.github/actions/setupmaven
+              with:
+                token: ${{ secrets.GITHUB_TOKEN }}
             - name: Download arm-ttk used in partner center pipeline
               run: |
                 wget -O arm-template-toolkit.zip https://aka.ms/arm-ttk-azureapps
@@ -36,20 +41,6 @@ jobs:
               uses: actions/checkout@v2
               with:
                 path: weblogic-azure
-            - name: Set up Apache Maven and JDK
-              uses: actions/setup-java@v1
-              with:
-                java-version: 1.8
-                server-id: github # Value of the distributionManagement/repository/id field of the pom.xml
-                server-username: MAVEN_USERNAME # env variable for username
-                server-password: MAVEN_TOKEN # env variable for token
-            - name: Set Maven env
-              env:
-                MAVEN_USERNAME: github
-                MAVEN_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-              run: |
-                echo "MAVEN_USERNAME=${MAVEN_USERNAME}" >> $GITHUB_ENV
-                echo "MAVEN_TOKEN=${MAVEN_TOKEN}" >> $GITHUB_ENV
             - name: Build and test weblogic-azure/weblogic-azure-aks
               run: mvn -Pbicep -Passembly clean install -Ptemplate-validation-tests --file weblogic-azure/weblogic-azure-aks/pom.xml
             - name: Generate artifact file name and path

--- a/.github/workflows/buildWlsVm4AsArtifact.yml
+++ b/.github/workflows/buildWlsVm4AsArtifact.yml
@@ -50,6 +50,11 @@ jobs:
           echo "pidType=${pidType}" >> $GITHUB_ENV
           echo "ref=${ref}" >> $GITHUB_ENV
       - uses: actions/checkout@v2.3.4
+      - name: Set up Maven with GitHub token
+        uses: ./.github/actions/setupmaven
+        with:
+          token: ${{ secrets.GITHUB_TOKEN }}
+      - uses: actions/checkout@v2.3.4
       - name: Set dependency reference
         uses: ./.github/actions/setvars
         with:
@@ -63,20 +68,6 @@ jobs:
         with:
           path: ${{ env.repoName }}
           ref: ${{ env.ref }}
-      - name: Set up Apache Maven and JDK
-        uses: actions/setup-java@v1
-        with:
-          java-version: 1.8
-          server-id: github # Value of the distributionManagement/repository/id field of the pom.xml
-          server-username: MAVEN_USERNAME # env variable for username
-          server-password: MAVEN_TOKEN # env variable for token
-      - name: Set Maven env
-        env:
-          MAVEN_USERNAME: github
-          MAVEN_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        run: |
-          echo "MAVEN_USERNAME=${MAVEN_USERNAME}" >> $GITHUB_ENV
-          echo "MAVEN_TOKEN=${MAVEN_TOKEN}" >> $GITHUB_ENV
       - name: Update utilities path location
         run:  |
            cd ${{env.repoName}}/weblogic-azure-vm/${{ env.offerName }}

--- a/.github/workflows/buildWlsVm4CcArtifact.yml
+++ b/.github/workflows/buildWlsVm4CcArtifact.yml
@@ -48,6 +48,11 @@ jobs:
           echo "pidType=${pidType}" >> $GITHUB_ENV
           echo "ref=${ref}" >> $GITHUB_ENV
       - uses: actions/checkout@v2.3.4
+      - name: Set up Maven with GitHub token
+        uses: ./.github/actions/setupmaven
+        with:
+          token: ${{ secrets.GITHUB_TOKEN }}
+      - uses: actions/checkout@v2.3.4
       - name: Set dependency reference
         uses: ./.github/actions/setvars
         with:
@@ -61,20 +66,6 @@ jobs:
         with:
           path: ${{ env.repoName }}
           ref: ${{ env.ref }}
-      - name: Set up Apache Maven and JDK
-        uses: actions/setup-java@v1
-        with:
-          java-version: 1.8
-          server-id: github # Value of the distributionManagement/repository/id field of the pom.xml
-          server-username: MAVEN_USERNAME # env variable for username
-          server-password: MAVEN_TOKEN # env variable for token
-      - name: Set Maven env
-        env:
-          MAVEN_USERNAME: github
-          MAVEN_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        run: |
-          echo "MAVEN_USERNAME=${MAVEN_USERNAME}" >> $GITHUB_ENV
-          echo "MAVEN_TOKEN=${MAVEN_TOKEN}" >> $GITHUB_ENV
       - name: Update utilities path location
         run:  |
            cd ${{env.repoName}}/weblogic-azure-vm/${{ env.offerName }}

--- a/.github/workflows/buildWlsVm4DcArtifact.yml
+++ b/.github/workflows/buildWlsVm4DcArtifact.yml
@@ -49,6 +49,11 @@ jobs:
           echo "pidType=${pidType}" >> $GITHUB_ENV
           echo "ref=${ref}" >> $GITHUB_ENV
       - uses: actions/checkout@v2.3.4
+      - name: Set up Maven with GitHub token
+        uses: ./.github/actions/setupmaven
+        with:
+          token: ${{ secrets.GITHUB_TOKEN }}
+      - uses: actions/checkout@v2.3.4
       - name: Download arm-ttk used in partner center pipeline
         run: |
           wget -O arm-template-toolkit.zip https://aka.ms/arm-ttk-azureapps
@@ -58,20 +63,6 @@ jobs:
         with:
           path: ${{ env.repoName }}
           ref: ${{ env.ref }}
-      - name: Set up Apache Maven and JDK
-        uses: actions/setup-java@v1
-        with:
-          java-version: 1.8
-          server-id: github # Value of the distributionManagement/repository/id field of the pom.xml
-          server-username: MAVEN_USERNAME # env variable for username
-          server-password: MAVEN_TOKEN # env variable for token
-      - name: Set Maven env
-        env:
-          MAVEN_USERNAME: github
-          MAVEN_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        run: |
-          echo "MAVEN_USERNAME=${MAVEN_USERNAME}" >> $GITHUB_ENV
-          echo "MAVEN_TOKEN=${MAVEN_TOKEN}" >> $GITHUB_ENV
       - name: Update utilities path location
         run:  |
            cd ${{env.repoName}}/weblogic-azure-vm/${{ env.offerName }}

--- a/.github/workflows/buildWlsVm4SnArtifact.yml
+++ b/.github/workflows/buildWlsVm4SnArtifact.yml
@@ -50,6 +50,11 @@ jobs:
           echo "pidType=${pidType}" >> $GITHUB_ENV
           echo "ref=${ref}" >> $GITHUB_ENV
       - uses: actions/checkout@v2.3.4
+      - name: Set up Maven with GitHub token
+        uses: ./.github/actions/setupmaven
+        with:
+          token: ${{ secrets.GITHUB_TOKEN }}
+      - uses: actions/checkout@v2.3.4
       - name: Download arm-ttk used in partner center pipeline
         run: |
           wget -O arm-template-toolkit.zip https://aka.ms/arm-ttk-azureapps
@@ -59,20 +64,6 @@ jobs:
         with:
           path: ${{ env.repoName }}
           ref: ${{ env.ref }}
-      - name: Set up Apache Maven and JDK
-        uses: actions/setup-java@v1
-        with:
-          java-version: 1.8
-          server-id: github # Value of the distributionManagement/repository/id field of the pom.xml
-          server-username: MAVEN_USERNAME # env variable for username
-          server-password: MAVEN_TOKEN # env variable for token
-      - name: Set Maven env
-        env:
-          MAVEN_USERNAME: github
-          MAVEN_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        run: |
-          echo "MAVEN_USERNAME=${MAVEN_USERNAME}" >> $GITHUB_ENV
-          echo "MAVEN_TOKEN=${MAVEN_TOKEN}" >> $GITHUB_ENV
       - name: Build and test ${{ env.offerName }} using ${{ env.pidType }} pids
         run: |
           cd ${{env.repoName}}/weblogic-azure-vm/${{ env.offerName }}

--- a/.github/workflows/newtag.yml
+++ b/.github/workflows/newtag.yml
@@ -94,10 +94,11 @@ jobs:
           mvn -Ptemplate-validation-tests clean install --file weblogic-azure-vm/arm-oraclelinux-wls-cluster/pom.xml -Dgit.repo.owner=${{ env.repoOwner }} -Dgit.tag=${{ env.ref }}
           mvn -Ptemplate-validation-tests clean install --file weblogic-azure-vm/arm-oraclelinux-wls-dynamic-cluster/pom.xml -Dgit.repo.owner=${{ env.repoOwner }} -Dgit.tag=${{ env.ref }}
 
-          echo "build bicep files"
-          bicep build weblogic-azure-aks/src/main/bicep/mainTemplate.bicep --outfile weblogic-azure-aks/src/main/arm/mainTemplate.json
-          bicep build weblogic-azure-aks/src/main/bicep/modules/setupDBConnection.bicep --outfile weblogic-azure-aks/src/main/arm/dbTemplate.json
-          bicep build weblogic-azure-aks/src/main/bicep/modules/updateWebLogicApplications.bicep --outfile weblogic-azure-aks/src/main/arm/updateAppTemplate.json
+          mvn -Ptemplate-validation-tests -Pbicep clean install --file weblogic-azure-aks/pom.xml -Dgit.repo.owner=${{ env.repoOwner }} -Dgit.tag=${{ env.ref }}
+          ls weblogic-azure-aks/target/bicep
+          bicep build weblogic-azure-aks/target/bicep/mainTemplate.bicep --outfile weblogic-azure-aks/src/main/arm/mainTemplate.json
+          bicep build weblogic-azure-aks/target/bicep/modules/setupDBConnection.bicep --outfile weblogic-azure-aks/src/main/arm/dbTemplate.json
+          bicep build weblogic-azure-aks/target/bicep/modules/updateWebLogicApplications.bicep --outfile weblogic-azure-aks/src/main/arm/updateAppTemplate.json
 
       - name: Create new tag
         run: |

--- a/.github/workflows/newtag.yml
+++ b/.github/workflows/newtag.yml
@@ -53,6 +53,11 @@ jobs:
           echo "tagname=${tagname}" >> $GITHUB_ENV
           echo "ref=${ref}" >> $GITHUB_ENV
       - uses: actions/checkout@v2.3.4
+      - name: Set up Maven with GitHub token
+        uses: ./.github/actions/setupmaven
+        with:
+          token: ${{ secrets.GITHUB_TOKEN }}
+      - uses: actions/checkout@v2.3.4
       - name: Set dependency reference
         uses: ./.github/actions/setvars
         with:
@@ -81,20 +86,6 @@ jobs:
           chmod +x ./bicep
           sudo mv ./bicep /usr/local/bin/bicep
           bicep --version
-      - name: Set up Apache Maven and JDK
-        uses: actions/setup-java@v1
-        with:
-          java-version: 1.8
-          server-id: github # Value of the distributionManagement/repository/id field of the pom.xml
-          server-username: MAVEN_USERNAME # env variable for username
-          server-password: MAVEN_TOKEN # env variable for token
-      - name: Set Maven env
-        env:
-          MAVEN_USERNAME: github
-          MAVEN_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        run: |
-          echo "MAVEN_USERNAME=${MAVEN_USERNAME}" >> $GITHUB_ENV
-          echo "MAVEN_TOKEN=${MAVEN_TOKEN}" >> $GITHUB_ENV
       - name: Build ${{ env.repoName }}
         run: |
           cd ${{ env.repoName }}

--- a/.github/workflows/setupWlsAksDependency.yml
+++ b/.github/workflows/setupWlsAksDependency.yml
@@ -8,7 +8,6 @@ on:
     types: [aks-deploy-dependency]
 
 env:
-    azCliVersion: 2.30.0
     azureCredentials: ${{ secrets.AZURE_CREDENTIALS }}
     location: eastus
     dbAdminUser: weblogic
@@ -21,8 +20,16 @@ env:
 
 jobs:
     preflight:
+        outputs: 
+          azCliVersion: ${{steps.get-external-dependencies-version.outputs.azCliVersion}}
         runs-on: ubuntu-latest
         steps:
+            - name: Get versions of external dependencies
+              id: get-external-dependencies-version
+              run: |
+                curl -Lo external-deps-versions.properties https://raw.githubusercontent.com/Azure/azure-javaee-iaas/main/external-deps-versions.properties
+                source external-deps-versions.properties
+                echo "azCliVersion=${AZ_CLI_VERSION}" >> $GITHUB_OUTPUT
             - name: Set up JDK 1.8
               uses: actions/setup-java@v1
               with:
@@ -31,6 +38,9 @@ jobs:
         needs: preflight
         runs-on: ubuntu-latest
         steps:
+            - name: Get AZ CLI Version
+              run: |
+                echo "azCliVersion=${{needs.preflight.outputs.azCliVersion}}" >> $GITHUB_ENV
             - uses: azure/login@v1
               id: azure-login
               with:
@@ -69,6 +79,9 @@ jobs:
         needs: preflight
         runs-on: ubuntu-latest
         steps:
+            - name: Get AZ CLI Version
+              run: |
+                echo "azCliVersion=${{needs.preflight.outputs.azCliVersion}}" >> $GITHUB_ENV
             - uses: azure/login@v1
               id: azure-login
               with:
@@ -95,7 +108,7 @@ jobs:
               with:
                 azcliversion: ${{ env.azCliVersion }}
                 inlineScript: |
-                    az storage container create -n ${{ env.storageContainerName }} --public-access container --account-name ${{ env.storageAccountName }}
+                    az storage container create -n ${{ env.storageContainerName }} --account-name ${{ env.storageAccountName }}
     format-db-sa-parameters-for-integration-test:
         needs: [deploy-storage-account, deploy-db]
         runs-on: ubuntu-latest

--- a/.github/workflows/testWlsAksWithDependencyCreation.yml
+++ b/.github/workflows/testWlsAksWithDependencyCreation.yml
@@ -39,7 +39,8 @@ env:
 
 jobs:
     preflight:
-        outputs:
+        outputs: 
+          artifactName: ${{steps.artifact_file.outputs.artifactName}}
           isForDemo: ${{ steps.setup-env-variables-based-on-dispatch-event.outputs.isForDemo }}
           gitUserNameForArtifactsLocation: ${{ steps.setup-env-variables-based-on-dispatch-event.outputs.gitUserNameForArtifactsLocation }}
           testBranchNameForArtifactsLocation: ${{ steps.setup-env-variables-based-on-dispatch-event.outputs.testBranchNameForArtifactsLocation }}
@@ -214,31 +215,14 @@ jobs:
             - name: Get AZ CLI Version
               run: |
                 echo "azCliVersion=${{needs.preflight.outputs.azCliVersion}}" >> $GITHUB_ENV
-            - uses: actions/checkout@v2.3.4
-            - name: Set up Maven with GitHub token
-              uses: ./.github/actions/setupmaven
-              with:
-                token: ${{ secrets.GITHUB_TOKEN }}
             - name: Checkout weblogic-azure
               uses: actions/checkout@v2
               with:
                 path: weblogic-azure
-            - name: Get version information from weblogic-azure/weblogic-azure-aks/pom.xml
-              id: version
-              run: |
-                version=$(mvn -q -Dexec.executable=echo -Dexec.args='${version.wls-on-aks-azure-marketplace}' --file weblogic-azure/pom.xml --non-recursive exec:exec)
-                echo $version
-                echo "version=${version}" >> $GITHUB_ENV
-            - name: Output artifact name for Download action
-              id: artifact_file
-              run: |
-                artifactName=wls-on-aks-azure-marketplace-$version-arm-assembly
-                echo "artifactName=${artifactName}" >> $GITHUB_ENV
-                echo "##[set-output name=artifactName;]${artifactName}"
             - name: Download artifact for deployment
               uses: actions/download-artifact@v1
               with:
-                name: ${{steps.artifact_file.outputs.artifactName}}
+                name: ${{needs.preflight.outputs.artifactName}}
             - uses: azure/login@v1
               id: azure-login
               with:
@@ -299,6 +283,8 @@ jobs:
               with:
                 azcliversion: ${{ env.azCliVersion }}
                 inlineScript: |
+                    artifactName=${{ needs.preflight.outputs.artifactName }}
+                    
                     az deployment group create \
                     --verbose \
                     --resource-group ${{ env.resourceGroupForWlsAks }} \

--- a/.github/workflows/testWlsAksWithDependencyCreation.yml
+++ b/.github/workflows/testWlsAksWithDependencyCreation.yml
@@ -75,20 +75,11 @@ jobs:
                 echo "isForDemo=${isForDemo}" >> $GITHUB_ENV
                 echo "gitUserNameForArtifactsLocation=${gitUserNameForArtifactsLocation}" >> $GITHUB_ENV
                 echo "testBranchNameForArtifactsLocation=${testBranchNameForArtifactsLocation}" >> $GITHUB_ENV
-            - name: Set up Apache Maven and JDK
-              uses: actions/setup-java@v1
+            - uses: actions/checkout@v2.3.4
+            - name: Set up Maven with GitHub token
+              uses: ./.github/actions/setupmaven
               with:
-                java-version: 1.8
-                server-id: github # Value of the distributionManagement/repository/id field of the pom.xml
-                server-username: MAVEN_USERNAME # env variable for username
-                server-password: MAVEN_TOKEN # env variable for token
-            - name: Set Maven env
-              env:
-                MAVEN_USERNAME: github
-                MAVEN_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-              run: |
-                echo "MAVEN_USERNAME=${MAVEN_USERNAME}" >> $GITHUB_ENV
-                echo "MAVEN_TOKEN=${MAVEN_TOKEN}" >> $GITHUB_ENV
+                token: ${{ secrets.GITHUB_TOKEN }}
             - name: Set up bicep
               run: |
                 curl -Lo bicep https://github.com/Azure/bicep/releases/download/${bicepVersion}/bicep-linux-x64
@@ -209,7 +200,7 @@ jobs:
               with:
                 azcliversion: ${{ env.azCliVersion }}
                 inlineScript: |
-                    az storage container create -n ${{ env.storageContainerName }} --public-access container --account-name ${{ env.storageAccountName }}
+                    az storage container create -n ${{ env.storageContainerName }}  --account-name ${{ env.storageAccountName }}
             - name: Upload built web app war file
               uses: azure/CLI@v1
               with:
@@ -223,6 +214,20 @@ jobs:
             - name: Get AZ CLI Version
               run: |
                 echo "azCliVersion=${{needs.preflight.outputs.azCliVersion}}" >> $GITHUB_ENV
+            - name: Set up Apache Maven and JDK
+              uses: actions/setup-java@v1
+              with:
+                java-version: 1.8
+                server-id: github # Value of the distributionManagement/repository/id field of the pom.xml
+                server-username: MAVEN_USERNAME # env variable for username
+                server-password: MAVEN_TOKEN # env variable for token
+            - name: Set Maven env
+              env:
+                MAVEN_USERNAME: github
+                MAVEN_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+              run: |
+                echo "MAVEN_USERNAME=${MAVEN_USERNAME}" >> $GITHUB_ENV
+                echo "MAVEN_TOKEN=${MAVEN_TOKEN}" >> $GITHUB_ENV
             - name: Checkout weblogic-azure
               uses: actions/checkout@v2
               with:
@@ -231,6 +236,7 @@ jobs:
               id: version
               run: |
                 version=$(mvn -q -Dexec.executable=echo -Dexec.args='${version.wls-on-aks-azure-marketplace}' --file weblogic-azure/pom.xml --non-recursive exec:exec)
+                echo $version
                 echo "version=${version}" >> $GITHUB_ENV
             - name: Output artifact name for Download action
               id: artifact_file
@@ -251,9 +257,22 @@ jobs:
               with:
                 azcliversion: ${{ env.azCliVersion }}
                 inlineScript: |
-                    cargoTrackerBlobUrl=$(az storage blob url --account-name ${{ env.storageAccountName }} --container-name ${{ env.storageContainerName }} --name cargo-tracker.war -o tsv)
-                    polishedUrl=$(echo ${cargoTrackerBlobUrl} | sed 's,/,\\\/,g')
-                    echo "cargoTrackerBlobUrl=${polishedUrl}" >> $GITHUB_ENV
+                    sasTokenValidTime=3600
+                    expiryData=$(( `date +%s`+${sasTokenValidTime}))
+                    sasEnd=`date -d@"$expiryData" -u '+%Y-%m-%dT%H:%MZ'`
+                    sasToken=$(az storage account generate-sas \
+                        --permissions r \
+                        --account-name ${{ env.storageAccountName }} \
+                        --services b \
+                        --resource-types sco \
+                        --expiry $sasEnd  -o tsv)
+                    cargoTrackerBlobUrl=$(az storage blob url \
+                        --container-name ${{ env.storageContainerName }} \
+                        --name cargo-tracker.war \
+                        --account-name ${{ env.storageAccountName }} \
+                        --sas-token ${sasToken} -o tsv)
+
+                    echo "cargoTrackerBlobUrl=${cargoTrackerBlobUrl}" >> $GITHUB_ENV
             - name: Create Resource Group
               uses: azure/CLI@v1
               with:
@@ -268,20 +287,21 @@ jobs:
                 path: cargotracker
             - name: Prepare parameter file
               run: |
-                echo "replace placeholders using real parameter"
-                sed -i "s/#location#/${location}/g; \
-                        s/#wlsUserName#/${wlsUserName}/g; \
-                        s/#wlsPassword#/${wlsPassword}/g; \
-                        s/#ocrSSOPSW#/${ocrSSOPSW}/g; \
-                        s/#ocrSSOUser#/${ocrSSOUser}/g; \
-                        s/#appPackageUrls#/${cargoTrackerBlobUrl}/g; \
-                        s/#wdtRuntimePassword#/${wdtRuntimePassword}/g; \
-                        s/#testbranchName#/${{ needs.preflight.outputs.testBranchNameForArtifactsLocation }}/g; \
-                        s/#gitUserName#/${{ needs.preflight.outputs.gitUserNameForArtifactsLocation }}/g; \
-                        s/#dbPassword#/${dbPassword}/g; \
-                        s/#dbUser#/${dbAdminUser}@${dbName}/g; \
-                        s/#dsConnectionURL#/jdbc:postgresql:\/\/${dbName}.postgres.database.azure.com:5432\/postgres/g" \
-                        weblogic-azure/weblogic-azure-aks/src/test/setupWlsAksParameters.jsonc
+                echo "generate parameter file"
+                bash weblogic-azure/weblogic-azure-aks/src/test/genWlsAksParameters.sh \
+                  ${{ needs.preflight.outputs.gitUserNameForArtifactsLocation }} \
+                  ${{ needs.preflight.outputs.testBranchNameForArtifactsLocation }} \
+                  "${cargoTrackerBlobUrl}" \
+                  ${dbPassword} \
+                  ${dbAdminUser}@${{ needs.preflight.outputs.dbName }} \
+                  jdbc:postgresql:\/\/${{ needs.preflight.outputs.dbName }}.postgres.database.azure.com:5432\/postgres \
+                  ${location} \
+                  ${ocrSSOPSW} \
+                  ${ocrSSOUser} \
+                  ${wdtRuntimePassword} \
+                  ${wlsPassword} \
+                  ${wlsUserName} \
+                  weblogic-azure/weblogic-azure-aks/src/test/setupWlsAksParameters.jsonc
             - name: Deploy WebLogic Server Cluster Domain offer
               id: deploy-wls-cluster
               uses: azure/CLI@v1

--- a/.github/workflows/testWlsAksWithDependencyCreation.yml
+++ b/.github/workflows/testWlsAksWithDependencyCreation.yml
@@ -284,8 +284,8 @@ jobs:
                   ${{ needs.preflight.outputs.testBranchNameForArtifactsLocation }} \
                   "${cargoTrackerBlobUrl}" \
                   ${dbPassword} \
-                  ${dbAdminUser}@${{ needs.preflight.outputs.dbName }} \
-                  jdbc:postgresql:\/\/${{ needs.preflight.outputs.dbName }}.postgres.database.azure.com:5432\/postgres \
+                  ${dbAdminUser}@${dbName} \
+                  jdbc:postgresql:\/\/${dbName}.postgres.database.azure.com:5432\/postgres \
                   ${location} \
                   ${ocrSSOPSW} \
                   ${ocrSSOUser} \

--- a/.github/workflows/testWlsAksWithDependencyCreation.yml
+++ b/.github/workflows/testWlsAksWithDependencyCreation.yml
@@ -214,20 +214,11 @@ jobs:
             - name: Get AZ CLI Version
               run: |
                 echo "azCliVersion=${{needs.preflight.outputs.azCliVersion}}" >> $GITHUB_ENV
-            - name: Set up Apache Maven and JDK
-              uses: actions/setup-java@v1
+            - uses: actions/checkout@v2.3.4
+            - name: Set up Maven with GitHub token
+              uses: ./.github/actions/setupmaven
               with:
-                java-version: 1.8
-                server-id: github # Value of the distributionManagement/repository/id field of the pom.xml
-                server-username: MAVEN_USERNAME # env variable for username
-                server-password: MAVEN_TOKEN # env variable for token
-            - name: Set Maven env
-              env:
-                MAVEN_USERNAME: github
-                MAVEN_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-              run: |
-                echo "MAVEN_USERNAME=${MAVEN_USERNAME}" >> $GITHUB_ENV
-                echo "MAVEN_TOKEN=${MAVEN_TOKEN}" >> $GITHUB_ENV
+                token: ${{ secrets.GITHUB_TOKEN }}
             - name: Checkout weblogic-azure
               uses: actions/checkout@v2
               with:

--- a/.github/workflows/testWlsAksWithoutDependencyCreation.yml
+++ b/.github/workflows/testWlsAksWithoutDependencyCreation.yml
@@ -104,20 +104,11 @@ jobs:
                 echo "isForDemo=${isForDemo}" >> $GITHUB_ENV
                 echo "gitUserNameForArtifactsLocation=${gitUserNameForArtifactsLocation}" >> $GITHUB_ENV
                 echo "testBranchNameForArtifactsLocation=${testBranchNameForArtifactsLocation}" >> $GITHUB_ENV
-            - name: Set up Apache Maven and JDK
-              uses: actions/setup-java@v1
+            - uses: actions/checkout@v2.3.4
+            - name: Set up Maven with GitHub token
+              uses: ./.github/actions/setupmaven
               with:
-                java-version: 1.8
-                server-id: github # Value of the distributionManagement/repository/id field of the pom.xml
-                server-username: MAVEN_USERNAME # env variable for username
-                server-password: MAVEN_TOKEN # env variable for token
-            - name: Set Maven env
-              env:
-                MAVEN_USERNAME: github
-                MAVEN_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-              run: |
-                echo "MAVEN_USERNAME=${MAVEN_USERNAME}" >> $GITHUB_ENV
-                echo "MAVEN_TOKEN=${MAVEN_TOKEN}" >> $GITHUB_ENV
+                token: ${{ secrets.GITHUB_TOKEN }}
             - name: Set up bicep
               run: |
                 curl -Lo bicep https://github.com/Azure/bicep/releases/download/${bicepVersion}/bicep-linux-x64
@@ -180,20 +171,11 @@ jobs:
             - name: Get AZ CLI Version
               run: |
                 echo "azCliVersion=${{needs.preflight.outputs.azCliVersion}}" >> $GITHUB_ENV
-            - name: Set up Apache Maven and JDK
-              uses: actions/setup-java@v1
+            - uses: actions/checkout@v2.3.4
+            - name: Set up Maven with GitHub token
+              uses: ./.github/actions/setupmaven
               with:
-                java-version: 1.8
-                server-id: github # Value of the distributionManagement/repository/id field of the pom.xml
-                server-username: MAVEN_USERNAME # env variable for username
-                server-password: MAVEN_TOKEN # env variable for token
-            - name: Set Maven env
-              env:
-                MAVEN_USERNAME: github
-                MAVEN_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-              run: |
-                echo "MAVEN_USERNAME=${MAVEN_USERNAME}" >> $GITHUB_ENV
-                echo "MAVEN_TOKEN=${MAVEN_TOKEN}" >> $GITHUB_ENV
+                token: ${{ secrets.GITHUB_TOKEN }}
             - name: Checkout weblogic-azure
               uses: actions/checkout@v2
               with:

--- a/.github/workflows/testWlsAksWithoutDependencyCreation.yml
+++ b/.github/workflows/testWlsAksWithoutDependencyCreation.yml
@@ -50,6 +50,7 @@ jobs:
     preflight:
         runs-on: ubuntu-latest
         outputs:
+          artifactName: ${{steps.artifact_file.outputs.artifactName}}
           resourceGroupForWlsAks: ${{ steps.setup-env-variables-based-on-dispatch-event.outputs.resourceGroupForWlsAks }}
           dbName: ${{ steps.setup-env-variables-based-on-dispatch-event.outputs.dbName }}
           storageAccountName: ${{ steps.setup-env-variables-based-on-dispatch-event.outputs.storageAccountName }}
@@ -171,30 +172,14 @@ jobs:
             - name: Get AZ CLI Version
               run: |
                 echo "azCliVersion=${{needs.preflight.outputs.azCliVersion}}" >> $GITHUB_ENV
-            - uses: actions/checkout@v2.3.4
-            - name: Set up Maven with GitHub token
-              uses: ./.github/actions/setupmaven
-              with:
-                token: ${{ secrets.GITHUB_TOKEN }}
             - name: Checkout weblogic-azure
               uses: actions/checkout@v2
               with:
                 path: weblogic-azure
-            - name: Get version information from weblogic-azure/weblogic-azure-aks/pom.xml
-              id: version
-              run: |
-                version=$(mvn -q -Dexec.executable=echo -Dexec.args='${version.wls-on-aks-azure-marketplace}' --file weblogic-azure/pom.xml --non-recursive exec:exec)
-                echo "version=${version}" >> $GITHUB_ENV
-            - name: Output artifact name for Download action
-              id: artifact_file
-              run: |
-                artifactName=wls-on-aks-azure-marketplace-$version-arm-assembly
-                echo "artifactName=${artifactName}" >> $GITHUB_ENV
-                echo "##[set-output name=artifactName;]${artifactName}"
             - name: Download artifact for deployment
               uses: actions/download-artifact@v1
               with:
-                name: ${{steps.artifact_file.outputs.artifactName}}
+                name: ${{needs.preflight.outputs.artifactName}}
             - uses: azure/login@v1
               id: azure-login
               with:
@@ -255,6 +240,8 @@ jobs:
               with:
                 azcliversion: ${{ env.azCliVersion }}
                 inlineScript: |
+                    artifactName=${{ needs.preflight.outputs.artifactName }}
+
                     az deployment group create \
                     --verbose \
                     --resource-group ${{ needs.preflight.outputs.resourceGroupForWlsAks }} \

--- a/.github/workflows/testWlsAksWithoutDependencyCreation.yml
+++ b/.github/workflows/testWlsAksWithoutDependencyCreation.yml
@@ -167,7 +167,12 @@ jobs:
               with:
                 azcliversion: ${{ env.azCliVersion }}
                 inlineScript: |
-                    az storage blob upload --account-name ${{ env.storageAccountName }} --container-name ${{ env.storageContainerName }} --file cargotracker/target/cargo-tracker.war --name cargo-tracker.war  
+                    az storage blob upload \
+                      --account-name ${{ env.storageAccountName }} \
+                      --container-name ${{ env.storageContainerName }} \
+                      --file cargotracker/target/cargo-tracker.war \
+                      --name cargo-tracker.war \
+                      --overwrite
     deploy-wls-on-aks:
         needs: preflight
         runs-on: ubuntu-latest
@@ -175,6 +180,20 @@ jobs:
             - name: Get AZ CLI Version
               run: |
                 echo "azCliVersion=${{needs.preflight.outputs.azCliVersion}}" >> $GITHUB_ENV
+            - name: Set up Apache Maven and JDK
+              uses: actions/setup-java@v1
+              with:
+                java-version: 1.8
+                server-id: github # Value of the distributionManagement/repository/id field of the pom.xml
+                server-username: MAVEN_USERNAME # env variable for username
+                server-password: MAVEN_TOKEN # env variable for token
+            - name: Set Maven env
+              env:
+                MAVEN_USERNAME: github
+                MAVEN_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+              run: |
+                echo "MAVEN_USERNAME=${MAVEN_USERNAME}" >> $GITHUB_ENV
+                echo "MAVEN_TOKEN=${MAVEN_TOKEN}" >> $GITHUB_ENV
             - name: Checkout weblogic-azure
               uses: actions/checkout@v2
               with:
@@ -203,9 +222,22 @@ jobs:
               with:
                 azcliversion: ${{ env.azCliVersion }}
                 inlineScript: |
-                    cargoTrackerBlobUrl=$(az storage blob url --account-name ${{ needs.preflight.outputs.storageAccountName }} --container-name ${{ needs.preflight.outputs.storageContainerName }} --name cargo-tracker.war -o tsv)
-                    polishedUrl=$(echo ${cargoTrackerBlobUrl} | sed 's,/,\\\/,g')
-                    echo "cargoTrackerBlobUrl=${polishedUrl}" >> $GITHUB_ENV
+                    sasTokenValidTime=3600
+                    expiryData=$(( `date +%s`+${sasTokenValidTime}))
+                    sasEnd=`date -d@"$expiryData" -u '+%Y-%m-%dT%H:%MZ'`
+                    sasToken=$(az storage account generate-sas \
+                        --permissions r \
+                        --account-name ${{ needs.preflight.outputs.storageAccountName }} \
+                        --services b \
+                        --resource-types sco \
+                        --expiry $sasEnd  -o tsv)
+                    cargoTrackerBlobUrl=$(az storage blob url \
+                        --container-name ${{ needs.preflight.outputs.storageContainerName }} \
+                        --name cargo-tracker.war \
+                        --account-name ${{ needs.preflight.outputs.storageAccountName }} \
+                        --sas-token ${sasToken} -o tsv)
+
+                    echo "cargoTrackerBlobUrl=${cargoTrackerBlobUrl}" >> $GITHUB_ENV
             - name: Create Resource Group
               uses: azure/CLI@v1
               with:
@@ -220,20 +252,21 @@ jobs:
                 path: cargotracker
             - name: Prepare parameter file
               run: |
-                echo "replace placeholders using real parameter"
-                sed -i "s/#location#/${location}/g; \
-                        s/#wlsUserName#/${wlsUserName}/g; \
-                        s/#wlsPassword#/${wlsPassword}/g; \
-                        s/#ocrSSOPSW#/${ocrSSOPSW}/g; \
-                        s/#ocrSSOUser#/${ocrSSOUser}/g; \
-                        s/#appPackageUrls#/${cargoTrackerBlobUrl}/g; \
-                        s/#wdtRuntimePassword#/${wdtRuntimePassword}/g; \
-                        s/#testbranchName#/${{ needs.preflight.outputs.testBranchNameForArtifactsLocation }}/g; \
-                        s/#gitUserName#/${{ needs.preflight.outputs.gitUserNameForArtifactsLocation }}/g; \
-                        s/#dbPassword#/${dbPassword}/g; \
-                        s/#dbUser#/${dbAdminUser}@${{ needs.preflight.outputs.dbName }}/g; \
-                        s/#dsConnectionURL#/jdbc:postgresql:\/\/${{ needs.preflight.outputs.dbName }}.postgres.database.azure.com:5432\/postgres/g" \
-                        weblogic-azure/weblogic-azure-aks/src/test/setupWlsAksParameters.jsonc
+                echo "generate parameter file"
+                bash weblogic-azure/weblogic-azure-aks/src/test/genWlsAksParameters.sh \
+                  ${{ needs.preflight.outputs.gitUserNameForArtifactsLocation }} \
+                  ${{ needs.preflight.outputs.testBranchNameForArtifactsLocation }} \
+                  "${cargoTrackerBlobUrl}" \
+                  ${dbPassword} \
+                  ${dbAdminUser}@${{ needs.preflight.outputs.dbName }} \
+                  jdbc:postgresql:\/\/${{ needs.preflight.outputs.dbName }}.postgres.database.azure.com:5432\/postgres \
+                  ${location} \
+                  ${ocrSSOPSW} \
+                  ${ocrSSOUser} \
+                  ${wdtRuntimePassword} \
+                  ${wlsPassword} \
+                  ${wlsUserName} \
+                  weblogic-azure/weblogic-azure-aks/src/test/setupWlsAksParameters.jsonc
             - name: Deploy WebLogic Server Cluster Domain offer
               id: deploy-wls-cluster
               uses: azure/CLI@v1

--- a/.github/workflows/testWlsVmAdmin.yml
+++ b/.github/workflows/testWlsVmAdmin.yml
@@ -49,6 +49,7 @@ jobs:
   preflight:
     outputs:
       enableELK: ${{ steps.setup-env-variables-based-on-dispatch-event.outputs.enableELK }}
+      artifactName: ${{steps.artifact_file.outputs.artifactName}}
     runs-on: ubuntu-latest
     steps:
       - name: Setup environment variables
@@ -203,7 +204,7 @@ jobs:
             --end-ip-address "0.0.0.0"
 
   deploy-weblogic-admin:
-    needs: deploy-dependencies
+    needs: [deploy-dependencies, preflight]
     runs-on: ubuntu-latest
     strategy:
       max-parallel: 1
@@ -226,31 +227,15 @@ jobs:
           ]
 
     steps:
-      - uses: actions/checkout@v2.3.4
-      - name: Set up Maven with GitHub token
-        uses: ./.github/actions/setupmaven
-        with:
-          token: ${{ secrets.GITHUB_TOKEN }}
       - name: Checkout ${{env.repoOwner}}/${{env.repoName}}
         uses: actions/checkout@v2
         with:
           repository: ${{env.repoOwner}}/${{env.repoName}}
           path: ${{env.repoName}}
-      - name: Get version information from ${{ env.offerName }}/pom.xml
-        id: version
-        run: |
-          version=$(mvn -q -Dexec.executable=echo -Dexec.args='${version.${{ env.offerName }}}' --file weblogic-azure/pom.xml --non-recursive exec:exec)
-          echo "version=${version}" >> $GITHUB_ENV
-      - name: Output artifact name for Download action
-        id: artifact_file
-        run: |
-          artifactName=${{ env.offerName }}-$version-arm-assembly
-          echo "artifactName=${artifactName}" >> $GITHUB_ENV
-          echo "##[set-output name=artifactName;]${artifactName}"
       - name: Download artifact for deployment
         uses: actions/download-artifact@v1
         with:
-          name: ${{steps.artifact_file.outputs.artifactName}}
+          name: ${{ needs.preflight.outputs.artifactName }}
 
       - uses: azure/login@v1
         id: azure-login
@@ -302,12 +287,15 @@ jobs:
       - name: Deploy WebLogic Server Admin only Domain offer
         id: deploy-wls-admin
         run: |
+            artifactName=${{ needs.preflight.outputs.artifactName }}
+            echo "artifactName=${{ needs.preflight.outputs.artifactName }}" >> $GITHUB_ENV
+
             az deployment group create \
               --verbose \
               --resource-group $resourceGroup \
               --name wls-admin-node \
               --parameters @${{ env.adminOfferPath }}/test/data/parameters-test.json \
-              --template-file ${{ env.offerName }}-$version-arm-assembly/mainTemplate.json
+              --template-file ${artifactName}/mainTemplate.json
 
       - name: Verify Network Security Group
         id: verify-nsg

--- a/.github/workflows/testWlsVmAdmin.yml
+++ b/.github/workflows/testWlsVmAdmin.yml
@@ -75,6 +75,11 @@ jobs:
           echo "enableELK=${enableELK}" >> $GITHUB_ENV
           echo "ref=${ref}" >> $GITHUB_ENV
       - uses: actions/checkout@v2.3.4
+      - name: Set up Maven with GitHub token
+        uses: ./.github/actions/setupmaven
+        with:
+          token: ${{ secrets.GITHUB_TOKEN }}
+      - uses: actions/checkout@v2.3.4
       - name: Set dependency reference
         uses: ./.github/actions/setvars
         with:
@@ -91,20 +96,6 @@ jobs:
           repository: ${{env.repoOwner}}/${{env.repoName}}
           ref: ${{ env.ref }}
           path: ${{env.repoName}}
-      - name: Set up Apache Maven and JDK
-        uses: actions/setup-java@v1
-        with:
-          java-version: 1.8
-          server-id: github # Value of the distributionManagement/repository/id field of the pom.xml
-          server-username: MAVEN_USERNAME # env variable for username
-          server-password: MAVEN_TOKEN # env variable for token
-      - name: Set Maven env
-        env:
-          MAVEN_USERNAME: github
-          MAVEN_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        run: |
-          echo "MAVEN_USERNAME=${MAVEN_USERNAME}" >> $GITHUB_ENV
-          echo "MAVEN_TOKEN=${MAVEN_TOKEN}" >> $GITHUB_ENV
       - name: Build and test ${{ env.offerName }}
         run: |
           ls
@@ -147,7 +138,7 @@ jobs:
       - name: Get version information from pom.xml
         id: version
         run: |
-          version=$(mvn -q -Dexec.executable=echo -Dexec.args='${{ env.offerName }}' --file weblogic-azure/pom.xml --non-recursive exec:exec)
+          version=$(mvn -q -Dexec.executable=echo -Dexec.args='${version.${{ env.offerName }}}' --file weblogic-azure/pom.xml --non-recursive exec:exec)
           echo "version=${version}" >> $GITHUB_ENV
       - name: Print version
         run: echo $version
@@ -235,6 +226,11 @@ jobs:
           ]
 
     steps:
+      - uses: actions/checkout@v2.3.4
+      - name: Set up Maven with GitHub token
+        uses: ./.github/actions/setupmaven
+        with:
+          token: ${{ secrets.GITHUB_TOKEN }}
       - name: Checkout ${{env.repoOwner}}/${{env.repoName}}
         uses: actions/checkout@v2
         with:
@@ -243,7 +239,7 @@ jobs:
       - name: Get version information from ${{ env.offerName }}/pom.xml
         id: version
         run: |
-          version=$(mvn -q -Dexec.executable=echo -Dexec.args='${{ env.offerName }}' --file weblogic-azure/pom.xml --non-recursive exec:exec)
+          version=$(mvn -q -Dexec.executable=echo -Dexec.args='${version.${{ env.offerName }}}' --file weblogic-azure/pom.xml --non-recursive exec:exec)
           echo "version=${version}" >> $GITHUB_ENV
       - name: Output artifact name for Download action
         id: artifact_file

--- a/.github/workflows/testWlsVmCluster.yml
+++ b/.github/workflows/testWlsVmCluster.yml
@@ -53,6 +53,11 @@ env:
 
 jobs:
   preflight:
+    outputs: 
+      artifactName: ${{steps.artifact_file.outputs.artifactName}}
+      addnodeArtifactName: ${{steps.addnode_artifact_file.outputs.addnode_artifactName}}
+      addCoherenceNodeArtifactName: ${{steps.addnode_coherence_artifact_file.outputs.addnode_coherence_artifactName}}
+      deletenodeArtifactName: ${{steps.deletenode_artifact_file.outputs.deletenode_artifactName}}
     runs-on: ubuntu-latest
     steps:
       - name: Setup environment variables
@@ -233,7 +238,7 @@ jobs:
           --end-ip-address "0.0.0.0"
 
   deploy-weblogic-cluster:
-    needs: deploy-dependencies
+    needs: [deploy-dependencies, preflight]
     runs-on: ubuntu-latest
     strategy:
       max-parallel: 1
@@ -255,31 +260,15 @@ jobs:
             "owls-141100-jdk11-rhel76;Oracle:weblogic-141100-jdk11-rhel76:owls-141100-jdk11-rhel76;latest"
           ]
     steps:
-      - uses: actions/checkout@v2.3.4
-      - name: Set up Maven with GitHub token
-        uses: ./.github/actions/setupmaven
-        with:
-          token: ${{ secrets.GITHUB_TOKEN }}
       - name: Checkout ${{env.repoOwner}}/${{env.repoName}}
         uses: actions/checkout@v2
         with:
           repository: ${{env.repoOwner}}/${{env.repoName}}
           path: ${{env.repoName}}
-      - name: Get version information from ${{ env.offerName }}/pom.xml
-        id: version
-        run: |
-          version=$(mvn -q -Dexec.executable=echo -Dexec.args='${version.${{ env.offerName }}}' --file weblogic-azure/pom.xml --non-recursive exec:exec)
-          echo "version=${version}" >> $GITHUB_ENV
-      - name: Output artifact name for Download action
-        id: artifact_file
-        run: |
-          artifactName=${{ env.offerName }}-$version-arm-assembly
-          echo "artifactName=${artifactName}" >> $GITHUB_ENV
-          echo "##[set-output name=artifactName;]${artifactName}"
       - name: Download artifact for deployment
         uses: actions/download-artifact@v1
         with:
-          name: ${{steps.artifact_file.outputs.artifactName}}
+          name: ${{ needs.preflight.outputs.artifactName }}
       - uses: azure/login@v1
         id: azure-login
         with:
@@ -332,6 +321,9 @@ jobs:
       - name: Deploy WebLogic Server Cluster Domain offer
         id: deploy-wls-cluster
         run: |
+            artifactName=${{ needs.preflight.outputs.artifactName }}
+            echo "artifactName=${{ needs.preflight.outputs.artifactName }}" >> $GITHUB_ENV
+
             az deployment group create \
               --verbose \
               --resource-group $resourceGroup \
@@ -729,21 +721,16 @@ jobs:
             --parameters @${{ env.offerPath }}/test/scripts/parameters-deploy-coherence.json \
             --template-file ${artifactName}/nestedtemplates/coherenceTemplate.json
 
-      - name: Output addnode artifact name
-        id: artifact_file_addnode
-        run: |
-          addnodeVersion=$(mvn -q -Dexec.executable=echo -Dexec.args='${version.arm-oraclelinux-wls-cluster-addnode}' --file weblogic-azure/pom.xml --non-recursive exec:exec)
-          artifactNameOfAddnode=${{ env.offerName }}-addnode-$addnodeVersion-arm-assembly
-          echo "artifactNameOfAddnode=${artifactNameOfAddnode}" >> $GITHUB_ENV
-          echo "##[set-output name=artifactNameOfAddnode;]${artifactNameOfAddnode}"
       - name: Download artifact for deployment
         uses: actions/download-artifact@v1
         with:
-          name: ${{steps.artifact_file_addnode.outputs.artifactNameOfAddnode}}
+          name: ${{ needs.preflight.outputs.addnodeArtifactName }}
 
       - name: Add new nodes to existing cluster
         id: add-node
         run: |
+            artifactNameOfAddnode=${{ needs.preflight.outputs.addnodeArtifactName }}
+
             echo "add two new nodes and enable app gateway"
             echo "generate add-node parameters"
             bash ${{ env.offerPath }}/test/scripts/gen-parameters-deploy-addnode.sh \
@@ -782,21 +769,16 @@ jobs:
             exit 1
           fi
 
-      - name: Output addnode-coherence artifact name
-        id: artifact_file_addnode_coherence
-        run: |
-          addnodeCoherenceVersion=$(mvn -q -Dexec.executable=echo -Dexec.args='${version.arm-oraclelinux-wls-cluster-addnode-coherence}' --file weblogic-azure/pom.xml --non-recursive exec:exec)
-          artifactNameOfAddnodeCo=${{ env.offerName }}-addnode-coherence-$addnodeCoherenceVersion-arm-assembly
-          echo "artifactNameOfAddnodeCo=${artifactNameOfAddnodeCo}" >> $GITHUB_ENV
-          echo "##[set-output name=artifactNameOfAddnodeCo;]${artifactNameOfAddnodeCo}"
       - name: Download artifact for deployment
         uses: actions/download-artifact@v1
         with:
-          name: ${{steps.artifact_file_addnode_coherence.outputs.artifactNameOfAddnodeCo}}
+          name: ${{ needs.preflight.outputs.addCoherenceNodeArtifactName }}
 
       - name: Add new cache node to coherence cluster
         id: add-node-coherence
         run: |
+            artifactNameOfAddnodeCo=${{ needs.preflight.outputs.addCoherenceNodeArtifactName }}
+
             echo "add new cache server"
             echo "generate parameters"
             bash ${{ env.offerPath }}/test/scripts/gen-parameters-deploy-addnode-coherence.sh \
@@ -835,21 +817,15 @@ jobs:
             exit 1
           fi
 
-      - name: Output delete-node artifact name
-        id: artifact_file_deletenode
-        run: |
-          deleteNodeVersion=$(awk '/<version>[^<]+<\/version>/{gsub(/<version>|<\/version>/,"",$1);print $1;exit;}' ${{ env.offerPath }}/deletenode/pom.xml)
-          addnodeCoherenceVersion=$(mvn -q -Dexec.executable=echo -Dexec.args='${version.arm-oraclelinux-wls-cluster-deletenode}' --file weblogic-azure/pom.xml --non-recursive exec:exec)
-          artifactNameOfDeleteNode=${{ env.offerName }}-deletenode-$deleteNodeVersion-arm-assembly
-          echo "artifactNameOfDeleteNode=${artifactNameOfDeleteNode}" >> $GITHUB_ENV
-          echo "##[set-output name=artifactNameOfDeleteNode;]${artifactNameOfDeleteNode}"
       - name: Download artifact for deployment
         uses: actions/download-artifact@v1
         with:
-          name: ${{steps.artifact_file_deletenode.outputs.artifactNameOfDeleteNode}}
+          name: ${{ needs.preflight.outputs.deletenodeArtifactName }}
       - name: Delete nodes from existing cluster
         id: delete-node
         run: |
+            artifactNameOfDeleteNode=${{ needs.preflight.outputs.deletenodeArtifactName }}
+            
             echo "generate delete-node parameters"
             bash ${{ env.offerPath }}/test/scripts/gen-parameters-deploy-deletenode.sh \
             <<< "${{ env.offerPath }}/test/scripts/parameters-deploy-deletenode.json \

--- a/.github/workflows/testWlsVmCluster.yml
+++ b/.github/workflows/testWlsVmCluster.yml
@@ -76,6 +76,11 @@ jobs:
           echo "enableELK=${enableELK}" >> $GITHUB_ENV
           echo "ref=${ref}" >> $GITHUB_ENV
       - uses: actions/checkout@v2.3.4
+      - name: Set up Maven with GitHub token
+        uses: ./.github/actions/setupmaven
+        with:
+          token: ${{ secrets.GITHUB_TOKEN }}
+      - uses: actions/checkout@v2.3.4
       - name: Set dependency reference
         uses: ./.github/actions/setvars
         with:
@@ -92,20 +97,6 @@ jobs:
           repository: ${{env.repoOwner}}/${{env.repoName}}
           path: ${{env.repoName}}
           ref: ${{ env.ref }}
-      - name: Set up Apache Maven and JDK
-        uses: actions/setup-java@v1
-        with:
-          java-version: 1.8
-          server-id: github # Value of the distributionManagement/repository/id field of the pom.xml
-          server-username: MAVEN_USERNAME # env variable for username
-          server-password: MAVEN_TOKEN # env variable for token
-      - name: Set Maven env
-        env:
-          MAVEN_USERNAME: github
-          MAVEN_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        run: |
-          echo "MAVEN_USERNAME=${MAVEN_USERNAME}" >> $GITHUB_ENV
-          echo "MAVEN_TOKEN=${MAVEN_TOKEN}" >> $GITHUB_ENV
       - name: Build and test ${{ env.offerName }}
         run: |
           mvn -Ptemplate-validation-tests clean install --file ${offerPath}/pom.xml -Dgit.repo.owner=${{ env.repoOwner }} -Dgit.tag=${{ env.ref }}
@@ -162,6 +153,7 @@ jobs:
         run: |
           addnode_version=$(mvn -q -Dexec.executable=echo -Dexec.args='${version.arm-oraclelinux-wls-cluster-addnode}' --file weblogic-azure/pom.xml --non-recursive exec:exec)
           addnode_artifactName=${{ env.offerName }}-addnode-$addnode_version-arm-assembly
+          ls ${{ env.offerPath }}/addnode/target
           unzip ${{ env.offerPath }}/addnode/target/$addnode_artifactName.zip -d ${{ env.offerPath }}/addnode/target/$addnode_artifactName
           echo "##[set-output name=addnode_artifactName;]${addnode_artifactName}"
           echo "##[set-output name=addnode_artifactPath;]${{ env.offerPath }}/addnode/target/$addnode_artifactName"
@@ -263,6 +255,11 @@ jobs:
             "owls-141100-jdk11-rhel76;Oracle:weblogic-141100-jdk11-rhel76:owls-141100-jdk11-rhel76;latest"
           ]
     steps:
+      - uses: actions/checkout@v2.3.4
+      - name: Set up Maven with GitHub token
+        uses: ./.github/actions/setupmaven
+        with:
+          token: ${{ secrets.GITHUB_TOKEN }}
       - name: Checkout ${{env.repoOwner}}/${{env.repoName}}
         uses: actions/checkout@v2
         with:

--- a/.github/workflows/testWlsVmDynamicCluster.yml
+++ b/.github/workflows/testWlsVmDynamicCluster.yml
@@ -55,6 +55,11 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2.3.4
+      - name: Set up Maven with GitHub token
+        uses: ./.github/actions/setupmaven
+        with:
+          token: ${{ secrets.GITHUB_TOKEN }}
+      - uses: actions/checkout@v2.3.4
       - name: Set dependency reference
         uses: ./.github/actions/setvars
         with:
@@ -70,20 +75,6 @@ jobs:
         with:
           repository: ${{env.repoOwner}}/${{env.repoName}}
           path: ${{env.repoName}}
-      - name: Set up Apache Maven and JDK
-        uses: actions/setup-java@v1
-        with:
-          java-version: 1.8
-          server-id: github # Value of the distributionManagement/repository/id field of the pom.xml
-          server-username: MAVEN_USERNAME # env variable for username
-          server-password: MAVEN_TOKEN # env variable for token
-      - name: Set Maven env
-        env:
-          MAVEN_USERNAME: github
-          MAVEN_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        run: |
-          echo "MAVEN_USERNAME=${MAVEN_USERNAME}" >> $GITHUB_ENV
-          echo "MAVEN_TOKEN=${MAVEN_TOKEN}" >> $GITHUB_ENV
       - name: Built and test ${{env.offerName}}
         run: mvn -Ptemplate-validation-tests clean install --file ${offerPath}/pom.xml
 
@@ -242,6 +233,11 @@ jobs:
             "owls-141100-jdk11-rhel76;Oracle:weblogic-141100-jdk11-rhel76:owls-141100-jdk11-rhel76;latest"
           ]
     steps:
+      - uses: actions/checkout@v2.3.4
+      - name: Set up Maven with GitHub token
+        uses: ./.github/actions/setupmaven
+        with:
+          token: ${{ secrets.GITHUB_TOKEN }}
       - name: Checkout ${{env.repoOwner}}/${{env.repoName}}
         uses: actions/checkout@v2
         with:

--- a/.github/workflows/testWlsVmDynamicCluster.yml
+++ b/.github/workflows/testWlsVmDynamicCluster.yml
@@ -52,6 +52,11 @@ env:
 
 jobs:
   preflight:
+    outputs: 
+      artifactName: ${{steps.artifact_file.outputs.artifactName}}
+      addnodeArtifactName: ${{steps.addnode_artifact_file.outputs.addnode_artifactName}}
+      addCoherenceNodeArtifactName: ${{steps.addnode_coherence_artifact_file.outputs.addnode_coherence_artifactName}}
+      deletenodeArtifactName: ${{steps.deletenode_artifact_file.outputs.deletenode_artifactName}}
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2.3.4
@@ -115,7 +120,7 @@ jobs:
       - name: Generate artifact file name and path
         id: artifact_file
         run: |
-          version=$(awk '/<version>[^<]+<\/version>/{gsub(/<version>|<\/version>/,"",$1);print $1;exit;}' ${offerPath}/${{ env.offerName }}/pom.xml)
+          version=$(mvn -q -Dexec.executable=echo -Dexec.args='${version.${{ env.offerName }}}' --file weblogic-azure/pom.xml --non-recursive exec:exec)
           artifactName=${{ env.offerName }}-$version-arm-assembly
           unzip ${offerPath}/${{ env.offerName }}/target/$artifactName.zip -d ${offerPath}/${{ env.offerName }}/target/$artifactName
           echo "##[set-output name=artifactName;]${artifactName}"
@@ -130,7 +135,7 @@ jobs:
       - name: Generate addnode artifact file name and path
         id: addnode_artifact_file
         run: |
-          addnode_version=$(awk '/<version>[^<]+<\/version>/{gsub(/<version>|<\/version>/,"",$1);print $1;exit;}' ${offerPath}/addnode/pom.xml)
+          addnode_version=$(mvn -q -Dexec.executable=echo -Dexec.args='${version.arm-oraclelinux-wls-dynamic-cluster-addnode}' --file weblogic-azure/pom.xml --non-recursive exec:exec)
           addnode_artifactName=${{ env.offerName }}-addnode-$addnode_version-arm-assembly
           unzip ${offerPath}/addnode/target/$addnode_artifactName.zip -d ${offerPath}/addnode/target/$addnode_artifactName
           echo "##[set-output name=addnode_artifactName;]${addnode_artifactName}"
@@ -145,7 +150,7 @@ jobs:
       - name: Generate delete node artifact file name and path
         id: deletenode_artifact_file
         run: |
-          deletenode_version=$(awk '/<version>[^<]+<\/version>/{gsub(/<version>|<\/version>/,"",$1);print $1;exit;}' ${offerPath}/deletenode/pom.xml)
+          deletenode_version=$(mvn -q -Dexec.executable=echo -Dexec.args='${version.arm-oraclelinux-wls-dynamic-cluster-deletenode}' --file weblogic-azure/pom.xml --non-recursive exec:exec)
           deletenode_artifactName=${{ env.offerName }}-deletenode-$deletenode_version-arm-assembly
           unzip ${offerPath}/deletenode/target/$deletenode_artifactName.zip -d ${offerPath}/deletenode/target/$deletenode_artifactName
           echo "##[set-output name=deletenode_artifactName;]${deletenode_artifactName}"
@@ -161,7 +166,7 @@ jobs:
       - name: Generate addnode-coherence artifact file name and path
         id: addnode_coherence_artifact_file
         run: |
-          addnode_coherence_version=$(awk '/<version>[^<]+<\/version>/{gsub(/<version>|<\/version>/,"",$1);print $1;exit;}' ${offerPath}/addnode-coherence/pom.xml)
+          addnode_coherence_version=$(mvn -q -Dexec.executable=echo -Dexec.args='${version.arm-oraclelinux-wls-dynamic-cluster-addnode-coherence}' --file weblogic-azure/pom.xml --non-recursive exec:exec)
           addnode_coherence_artifactName=${{ env.offerName }}-addnode-coherence-$addnode_coherence_version-arm-assembly
           unzip ${offerPath}/addnode-coherence/target/$addnode_coherence_artifactName.zip -d ${offerPath}/addnode-coherence/target/$addnode_coherence_artifactName
           echo "##[set-output name=addnode_coherence_artifactName;]${addnode_coherence_artifactName}"
@@ -233,31 +238,15 @@ jobs:
             "owls-141100-jdk11-rhel76;Oracle:weblogic-141100-jdk11-rhel76:owls-141100-jdk11-rhel76;latest"
           ]
     steps:
-      - uses: actions/checkout@v2.3.4
-      - name: Set up Maven with GitHub token
-        uses: ./.github/actions/setupmaven
-        with:
-          token: ${{ secrets.GITHUB_TOKEN }}
       - name: Checkout ${{env.repoOwner}}/${{env.repoName}}
         uses: actions/checkout@v2
         with:
           repository: ${{env.repoOwner}}/${{env.repoName}}
           path: ${{env.repoName}}
-      - name: Get version information from ${{env.offerName}}/pom.xml
-        id: version
-        run: |
-          version=$(mvn -q -Dexec.executable=echo -Dexec.args='${version.${offerName}}' --file weblogic-azure/pom.xml --non-recursive exec:exec)
-          echo "version=${version}" >> $GITHUB_ENV
-      - name: Output artifact name for Download action
-        id: artifact_file
-        run: |
-          artifactName=${offerName}-$version-arm-assembly
-          echo "artifactName=${artifactName}" >> $GITHUB_ENV
-          echo "##[set-output name=artifactName;]${artifactName}"
       - name: Download artifact for deployment
         uses: actions/download-artifact@v1
         with:
-          name: ${{steps.artifact_file.outputs.artifactName}}
+          name: ${{ needs.preflight.outputs.artifactName }}
       - uses: azure/login@v1
         id: azure-login
         with:
@@ -313,6 +302,9 @@ jobs:
       - name: Deploy WebLogic Server Dynamic Cluster Domain offer
         id: deploy-wls-dycluster
         run: |
+            artifactName=${{ needs.preflight.outputs.artifactName }}
+            echo "artifactName=${{ needs.preflight.outputs.artifactName }}" >> $GITHUB_ENV
+            
             az deployment group create \
               --verbose \
               --resource-group $resourceGroup \
@@ -553,21 +545,16 @@ jobs:
             --parameters @${offerPath}/test/scripts/parameters-deploy-coherence.json \
             --template-file ${artifactName}/nestedtemplates/coherenceTemplate.json
 
-      - name: Output addnode artifact name
-        id: artifact_file_addnode
-        run: |
-          addnodeVersion=$(mvn -q -Dexec.executable=echo -Dexec.args='${version.arm-oraclelinux-wls-dynamic-cluster-addnode}' --file weblogic-azure/pom.xml --non-recursive exec:exec)
-          artifactNameOfAddnode=${offerName}-addnode-$addnodeVersion-arm-assembly
-          echo "artifactNameOfAddnode=${artifactNameOfAddnode}" >> $GITHUB_ENV
-          echo "##[set-output name=artifactNameOfAddnode;]${artifactNameOfAddnode}"
       - name: Download artifact for deployment
         uses: actions/download-artifact@v1
         with:
-          name: ${{steps.artifact_file_addnode.outputs.artifactNameOfAddnode}}
+          name: ${{ needs.preflight.outputs.addnodeArtifactName }}
 
       - name: Add new nodes to existing cluster
         id: add-node
         run: |
+            artifactNameOfAddnode=${{ needs.preflight.outputs.addnodeArtifactName }}
+
             echo "add two new nodes"
             echo "generate add-node parameters"
             bash ${offerPath}/test/scripts/gen-parameters-deploy-addnode.sh  <<< \
@@ -609,21 +596,16 @@ jobs:
             exit 1
           fi
 
-      - name: Output addnode-coherence artifact name
-        id: artifact_file_addnode_coherence
-        run: |
-          addnodeCoherenceVersion=$(awk '/<version>[^<]+<\/version>/{gsub(/<version>|<\/version>/,"",$1);print $1;exit;}' ${offerPath}/addnode-coherence/pom.xml)
-          artifactNameOfAddnodeCo=${offerName}-addnode-coherence-$addnodeCoherenceVersion-arm-assembly
-          echo "artifactNameOfAddnodeCo=${artifactNameOfAddnodeCo}" >> $GITHUB_ENV
-          echo "##[set-output name=artifactNameOfAddnodeCo;]${artifactNameOfAddnodeCo}"
       - name: Download artifact for deployment
         uses: actions/download-artifact@v1
         with:
-          name: ${{steps.artifact_file_addnode_coherence.outputs.artifactNameOfAddnodeCo}}
+          name: ${{ needs.preflight.outputs.addCoherenceNodeArtifactName }}
 
       - name: Add new cache node to coherence cluster
         id: add-node-coherence
         run: |
+            artifactNameOfAddnodeCo=${{ needs.preflight.outputs.addCoherenceNodeArtifactName }}
+
             echo "add new cache server"
             echo "generate parameters"
             bash ${offerPath}/test/scripts/gen-parameters-deploy-addnode-coherence.sh  <<< \
@@ -662,20 +644,15 @@ jobs:
             exit 1
           fi
 
-      - name: Output delete-node artifact name
-        id: artifact_file_deletenode
-        run: |
-          deleteNodeVersion=$(awk '/<version>[^<]+<\/version>/{gsub(/<version>|<\/version>/,"",$1);print $1;exit;}' ${offerPath}/deletenode/pom.xml)
-          artifactNameOfDeleteNode=${offerName}-deletenode-$deleteNodeVersion-arm-assembly
-          echo "artifactNameOfDeleteNode=${artifactNameOfDeleteNode}" >> $GITHUB_ENV
-          echo "##[set-output name=artifactNameOfDeleteNode;]${artifactNameOfDeleteNode}"
       - name: Download artifact for deployment
         uses: actions/download-artifact@v1
         with:
-          name: ${{steps.artifact_file_deletenode.outputs.artifactNameOfDeleteNode}}
+          name: ${{ needs.preflight.outputs.deletenodeArtifactName }}
       - name: Delete nodes from existing cluster
         id: delete-node
         run: |
+            artifactNameOfDeleteNode=${{ needs.preflight.outputs.deletenodeArtifactName }}
+            
             echo "generate delete-node parameters"
             bash ${offerPath}/test/scripts/gen-parameters-deploy-deletenode.sh <<< \
             "${offerPath}/test/scripts/parameters-deploy-deletenode.json \

--- a/weblogic-azure-aks/src/test/genWlsAksParameters.sh
+++ b/weblogic-azure-aks/src/test/genWlsAksParameters.sh
@@ -1,10 +1,29 @@
+#!/bin/bash
+# Copyright (c) 2023, Oracle and/or its affiliates.
+# Licensed under the Universal Permissive License v 1.0 as shown at https://oss.oracle.com/licenses/upl.
+
+gitUserName=$1
+testbranchName=$2
+appPackageUrls=$3
+dbPassword=$4
+dbUser=$5
+dsConnectionURL=$6
+location=$7
+ocrSSOPSW=$8
+ocrSSOUser=$9
+wdtRuntimePassword=${10}
+wlsPassword=${11}
+wlsUserName=${12}
+parametersPath=${13}
+
+cat <<EOF > ${parametersPath}
 {
-    "$schema": "https://schema.management.azure.com/schemas/2015-01-01/deploymentParameters.json#",
+    "\$schema": "https://schema.management.azure.com/schemas/2015-01-01/deploymentParameters.json#",
     "contentVersion": "1.0.0.0",
     // This file is used by CI/CD workflows. It allows the workflows to provide parameters when invoking the offer from the command line.
     "parameters": {
         "_artifactsLocation": {
-            "value": "https://raw.githubusercontent.com/#gitUserName#/weblogic-azure/#testbranchName#/weblogic-azure-aks/src/main/arm/"
+            "value": "https://raw.githubusercontent.com/${gitUserName}/weblogic-azure/${testbranchName}/weblogic-azure-aks/src/main/arm/"
         },
         "aksAgentPoolNodeCount": {
             "value": 3
@@ -23,7 +42,7 @@
         },
         "appPackageUrls": {
             "value": [
-                "#appPackageUrls#"
+                "${appPackageUrls}"
             ]
         },
         "appReplicas": {
@@ -42,16 +61,16 @@
             "value": "EmulateTwoPhaseCommit"
         },
         "dbPassword": {
-            "value": "#dbPassword#"
+            "value": "${dbPassword}"
         },
         "dbUser": {
-            "value": "#dbUser#"
+            "value": "${dbUser}"
         },
         "databaseType": {
             "value": "postgresql"
         },
         "dsConnectionURL": {
-            "value": "#dsConnectionURL#"
+            "value": "${dsConnectionURL}"
         },
         "enableAppGWIngress": {
             "value": true
@@ -78,13 +97,13 @@
             "value": "jdbc/CargoTrackerDB"
         },
         "location": {
-            "value": "#location#"
+            "value": "${location}"
         },
         "ocrSSOPSW": {
-            "value": "#ocrSSOPSW#"
+            "value": "${ocrSSOPSW}"
         },
         "ocrSSOUser": {
-            "value": "#ocrSSOUser#"
+            "value": "${ocrSSOUser}"
         },
         "useInternalLB": {
             "value": false
@@ -93,16 +112,17 @@
             "value": true
         },
         "wdtRuntimePassword": {
-            "value": "#wdtRuntimePassword#"
+            "value": "${wdtRuntimePassword}"
         },
         "wlsImageTag": {
             "value": "14.1.1.0-11"
         },
         "wlsPassword": {
-            "value": "#wlsPassword#"
+            "value": "${wlsPassword}"
         },
         "wlsUserName": {
-            "value": "#wlsUserName#"
+            "value": "${wlsUserName}"
         }
     }
 }
+EOF

--- a/weblogic-azure-vm/arm-oraclelinux-wls-cluster/addnode-coherence/pom.xml
+++ b/weblogic-azure-vm/arm-oraclelinux-wls-cluster/addnode-coherence/pom.xml
@@ -28,6 +28,8 @@
     <properties>
         <test.parameters>-TestParameter '@{&quot;SampleName&quot;=&quot;addnode-coherence/src/main&quot;;&quot;RawRepoPath&quot;=&quot;${artifactsLocationBase}/arm-oraclelinux-wls-cluster/&quot;}'</test.parameters>
         <module.basedir>${project.parent.basedir}</module.basedir>
+        <assembly.skipAssembly>false</assembly.skipAssembly>
+        <skip.exec.plugin>false</skip.exec.plugin>
     </properties>
 
     <description>

--- a/weblogic-azure-vm/arm-oraclelinux-wls-cluster/addnode/pom.xml
+++ b/weblogic-azure-vm/arm-oraclelinux-wls-cluster/addnode/pom.xml
@@ -28,6 +28,8 @@
     <properties>
         <test.parameters>-TestParameter '@{&quot;SampleName&quot;=&quot;addnode/src/main&quot;;&quot;RawRepoPath&quot;=&quot;${artifactsLocationBase}/arm-oraclelinux-wls-cluster/&quot;}'</test.parameters>
         <module.basedir>${project.parent.basedir}</module.basedir>
+        <assembly.skipAssembly>false</assembly.skipAssembly>
+        <skip.exec.plugin>false</skip.exec.plugin>
     </properties>
 
     <description>

--- a/weblogic-azure-vm/arm-oraclelinux-wls-cluster/deletenode/pom.xml
+++ b/weblogic-azure-vm/arm-oraclelinux-wls-cluster/deletenode/pom.xml
@@ -28,6 +28,8 @@
     <properties>
         <test.parameters>-TestParameter '@{&quot;SampleName&quot;=&quot;deletenode/src/main&quot;;&quot;RawRepoPath&quot;=&quot;${artifactsLocationBase}/arm-oraclelinux-wls-cluster/&quot;}'</test.parameters>
         <module.basedir>${project.parent.basedir}</module.basedir>
+        <assembly.skipAssembly>false</assembly.skipAssembly>
+        <skip.exec.plugin>false</skip.exec.plugin>
     </properties>
 
     <description>

--- a/weblogic-azure-vm/arm-oraclelinux-wls-dynamic-cluster/addnode-coherence/pom.xml
+++ b/weblogic-azure-vm/arm-oraclelinux-wls-dynamic-cluster/addnode-coherence/pom.xml
@@ -26,6 +26,8 @@
     <properties>
         <test.parameters>-TestParameter '@{&quot;SampleName&quot;=&quot;addnode-coherence/src/main&quot;;&quot;RawRepoPath&quot;=&quot;${artifactsLocationBase}/arm-oraclelinux-wls-dynamic-cluster/&quot;}'</test.parameters>
         <module.basedir>${project.parent.basedir}</module.basedir>
+        <assembly.skipAssembly>false</assembly.skipAssembly>
+        <skip.exec.plugin>false</skip.exec.plugin>
     </properties>
 
     <description>

--- a/weblogic-azure-vm/arm-oraclelinux-wls-dynamic-cluster/addnode/pom.xml
+++ b/weblogic-azure-vm/arm-oraclelinux-wls-dynamic-cluster/addnode/pom.xml
@@ -26,6 +26,8 @@
     <properties>
         <test.parameters>-TestParameter '@{&quot;SampleName&quot;=&quot;addnode/src/main&quot;;&quot;RawRepoPath&quot;=&quot;${artifactsLocationBase}/arm-oraclelinux-wls-dynamic-cluster/&quot;}'</test.parameters>
         <module.basedir>${project.parent.basedir}</module.basedir>
+        <assembly.skipAssembly>false</assembly.skipAssembly>
+        <skip.exec.plugin>false</skip.exec.plugin>
     </properties>
 
     <description>

--- a/weblogic-azure-vm/arm-oraclelinux-wls-dynamic-cluster/deletenode/pom.xml
+++ b/weblogic-azure-vm/arm-oraclelinux-wls-dynamic-cluster/deletenode/pom.xml
@@ -28,6 +28,8 @@
     <properties>
         <test.parameters>-TestParameter '@{&quot;SampleName&quot;=&quot;deletenode/src/main&quot;;&quot;RawRepoPath&quot;=&quot;${artifactsLocationBase}/arm-oraclelinux-wls-dynamic-cluster/&quot;}'</test.parameters>
         <module.basedir>${project.parent.basedir}</module.basedir>
+        <assembly.skipAssembly>false</assembly.skipAssembly>
+        <skip.exec.plugin>false</skip.exec.plugin>
     </properties>
 
     <description>

--- a/weblogic-azure-vm/arm-oraclelinux-wls/src/main/resources/azure-common.properties
+++ b/weblogic-azure-vm/arm-oraclelinux-wls/src/main/resources/azure-common.properties
@@ -33,7 +33,7 @@ azure.apiVersionForVirtualNetworks=2023-06-01
 # Microsoft.OperationalInsights/workspaces
 azure.apiVersionForInsightsWorkspaces=2022-10-01
 # Microsoft.Resources/deploymentScripts
-azure.apiVersionForDeploymentScript=2020-10-01
+azure.apiVersionForDeploymentScript=2023-08-01
 # Microsoft.Resources/deployments
 azure.apiVersionForDeployment=2022-09-01
 # Microsoft.Resources/tags


### PR DESCRIPTION
- Fix failure that caused by `az storage` command. Remove public access container and access WAR file with SaS URL.
- Use a shell script to generate testing parameter file, to avoid `sed` replacing problems.
- Fix failure that introduced by Maven commands that query artifacts version.
- Create a local action to set Maven ENV.
- Update deployment script API version with 2023-08-01.