### PR TITLE
Removed Red Hat Linux 7.6 options at portal deployment

### DIFF
--- a/weblogic-azure-vm/arm-oraclelinux-wls-admin/src/main/arm/createUiDefinition.json
+++ b/weblogic-azure-vm/arm-oraclelinux-wls-admin/src/main/arm/createUiDefinition.json
@@ -59,19 +59,7 @@
                         {
                             "label": "WebLogic Server 12.2.1.4.0 and JDK8 on Red Hat Enterprise Linux 8.7",
                             "value": "owls-122140-jdk8-rhel87;Oracle:weblogic-122140-jdk8-rhel87:owls-122140-jdk8-rhel87;latest"                            
-                        },                        
-                        {
-                            "label": "WebLogic Server 12.2.1.4.0 and JDK8 on Red Hat Enterprise Linux 7.6",
-                            "value": "owls-122140-jdk8-rhel76;Oracle:weblogic-122140-jdk8-rhel76:owls-122140-jdk8-rhel76;latest"
-                        },
-                        {
-                            "label": "WebLogic Server 14.1.1.0.0 and JDK8 on Red Hat Enterprise Linux 7.6",
-                            "value": "owls-141100-jdk8-rhel76;Oracle:weblogic-141100-jdk8-rhel76:owls-141100-jdk8-rhel76;latest"
-                        },
-                        {
-                            "label": "WebLogic Server 14.1.1.0.0 and JDK11 on Red Hat Enterprise Linux 7.6",
-                            "value": "owls-141100-jdk11-rhel76;Oracle:weblogic-141100-jdk11-rhel76:owls-141100-jdk11-rhel76;latest"
-                        }
+                        }                        
                     ],
                     "required": true
                 },

--- a/weblogic-azure-vm/arm-oraclelinux-wls-cluster/arm-oraclelinux-wls-cluster/src/main/arm/createUiDefinition.json
+++ b/weblogic-azure-vm/arm-oraclelinux-wls-cluster/arm-oraclelinux-wls-cluster/src/main/arm/createUiDefinition.json
@@ -59,19 +59,7 @@
                         {
                             "label": "WebLogic Server 12.2.1.4.0 and JDK8 on Red Hat Enterprise Linux 8.7",
                             "value": "owls-122140-jdk8-rhel87;Oracle:weblogic-122140-jdk8-rhel87:owls-122140-jdk8-rhel87;latest"                            
-                        },                        
-                        {
-                            "label": "WebLogic Server 12.2.1.4.0 and JDK8 on Red Hat Enterprise Linux 7.6",
-                            "value": "owls-122140-jdk8-rhel76;Oracle:weblogic-122140-jdk8-rhel76:owls-122140-jdk8-rhel76;latest"
-                        },
-                        {
-                            "label": "WebLogic Server 14.1.1.0.0 and JDK8 on Red Hat Enterprise Linux 7.6",
-                            "value": "owls-141100-jdk8-rhel76;Oracle:weblogic-141100-jdk8-rhel76:owls-141100-jdk8-rhel76;latest"
-                        },
-                        {
-                            "label": "WebLogic Server 14.1.1.0.0 and JDK11 on Red Hat Enterprise Linux 7.6",
-                            "value": "owls-141100-jdk11-rhel76;Oracle:weblogic-141100-jdk11-rhel76:owls-141100-jdk11-rhel76;latest"
-                        }
+                        }                        
                     ],
                     "required": true
                 },

--- a/weblogic-azure-vm/arm-oraclelinux-wls-dynamic-cluster/arm-oraclelinux-wls-dynamic-cluster/src/main/arm/createUiDefinition.json
+++ b/weblogic-azure-vm/arm-oraclelinux-wls-dynamic-cluster/arm-oraclelinux-wls-dynamic-cluster/src/main/arm/createUiDefinition.json
@@ -59,18 +59,6 @@
                         {
                             "label": "WebLogic Server 12.2.1.4.0 and JDK8 on Red Hat Enterprise Linux 8.7",
                             "value": "owls-122140-jdk8-rhel87;Oracle:weblogic-122140-jdk8-rhel87:owls-122140-jdk8-rhel87;latest"                            
-                        },                        
-                        {
-                            "label": "WebLogic Server 12.2.1.4.0 and JDK8 on Red Hat Enterprise Linux 7.6",
-                            "value": "owls-122140-jdk8-rhel76;Oracle:weblogic-122140-jdk8-rhel76:owls-122140-jdk8-rhel76;latest"                            
-                        },
-                        {
-                            "label": "WebLogic Server 14.1.1.0.0 and JDK8 on Red Hat Enterprise Linux 7.6",
-                            "value": "owls-141100-jdk8-rhel76;Oracle:weblogic-141100-jdk8-rhel76:owls-141100-jdk8-rhel76;latest"                            
-                        },
-                        {
-                            "label": "WebLogic Server 14.1.1.0.0 and JDK11 on Red Hat Enterprise Linux 7.6",
-                            "value": "owls-141100-jdk11-rhel76;Oracle:weblogic-141100-jdk11-rhel76:owls-141100-jdk11-rhel76;latest"                            
                         }                        
                     ],
                     "required": true

--- a/weblogic-azure-vm/arm-oraclelinux-wls/src/main/arm/createUiDefinition.json
+++ b/weblogic-azure-vm/arm-oraclelinux-wls/src/main/arm/createUiDefinition.json
@@ -59,18 +59,6 @@
                         {
                             "label": "WebLogic Server 12.2.1.4.0 and JDK8 on Red Hat Enterprise Linux 8.7",
                             "value": "owls-122140-jdk8-rhel87;Oracle:weblogic-122140-jdk8-rhel87:owls-122140-jdk8-rhel87;latest"                            
-                        },
-                        {
-                            "label": "WebLogic Server 12.2.1.4.0 and JDK8 on Red Hat Enterprise Linux 7.6",
-                            "value": "owls-122140-jdk8-rhel76;Oracle:weblogic-122140-jdk8-rhel76:owls-122140-jdk8-rhel76;latest"                            
-                        },
-                        {
-                            "label": "WebLogic Server 14.1.1.0.0 and JDK8 on Red Hat Enterprise Linux 7.6",
-                            "value": "owls-141100-jdk8-rhel76;Oracle:weblogic-141100-jdk8-rhel76:owls-141100-jdk8-rhel76;latest"                            
-                        },
-                        {
-                            "label": "WebLogic Server 14.1.1.0.0 and JDK11 on Red Hat Enterprise Linux 7.6",
-                            "value": "owls-141100-jdk11-rhel76;Oracle:weblogic-141100-jdk11-rhel76:owls-141100-jdk11-rhel76;latest"                            
                         }
                     ],
                     "required": true


### PR DESCRIPTION
Removed RHEL7.6 options from Microsoft partner site deployment. But it can be deployed using ARM template deployment.