### PR TITLE
Update var.yml to new tag 2024-02-29-1-Q1.

### DIFF
--- a/_data/var.yml
+++ b/_data/var.yml
@@ -22,4 +22,4 @@ passwordInFileNote: |-3
    * We did not include values for parameters that have a default value.
    * Even though this parameters file has values for sensitive fields such as passwords, these values are not echoed on the command line, or repeated in the logs because they are passed directly as `secureString` type in ARM.  **Please ensure any occurrences of the parameters file in the filesystem are sufficiently secured.**
    
-artifactsLocationTag: 2022-12-30-3-Q4
+artifactsLocationTag: 2024-02-29-1-Q1


### PR DESCRIPTION
This PR makes our documentation at https://oracle.github.io/weblogic-azure/aks/ and https://oracle.github.io/weblogic-azure/vms/ current with the latest tag.
This pull request includes a minor change to the `var.yml` file. The `artifactsLocationTag` value has been updated to reflect the new date and quarter.