### PR TITLE
Upgrade PowerShell and use version 11.5

### DIFF
--- a/.github/workflows/testWlsAksWithDependencyCreation.yml
+++ b/.github/workflows/testWlsAksWithDependencyCreation.yml
@@ -147,7 +147,7 @@ jobs:
                     --public-network-access Enabled \
                     --admin-password ${{ env.dbPassword }} \
                     --sku-name B_Gen5_1
-                    sleep 1m
+                    sleep 2m
                     echo "Allow Access To Azure Services"
                     az postgres server firewall-rule create \
                     -g ${{ env.resourceGroupForDB }} \

--- a/.github/workflows/testWlsVmCluster.yml
+++ b/.github/workflows/testWlsVmCluster.yml
@@ -229,6 +229,8 @@ jobs:
           --admin-password ${{ env.wlsPassword }} \
           --sku-name B_Gen5_1
 
+          sleep 2m
+          
           echo "Allow Access To Azure Services"
           az postgres server firewall-rule create \
           -g ${{ env.resourceGroupForDependency }} \

--- a/pom.xml
+++ b/pom.xml
@@ -40,11 +40,11 @@
     <properties>    
         <!--  versions  start -->
         <!--  weblogic azure aks versions  -->
-        <version.wls-on-aks-azure-marketplace>1.0.72</version.wls-on-aks-azure-marketplace>
+        <version.wls-on-aks-azure-marketplace>1.0.74</version.wls-on-aks-azure-marketplace>
         <!--  weblogic azure vm versions  -->
         <version.arm-oraclelinux-wls>1.0.27</version.arm-oraclelinux-wls>
         <version.arm-oraclelinux-wls-admin>1.0.50</version.arm-oraclelinux-wls-admin>
-        <version.arm-oraclelinux-wls-cluster>1.0.650000</version.arm-oraclelinux-wls-cluster>
+        <version.arm-oraclelinux-wls-cluster>1.0.660000</version.arm-oraclelinux-wls-cluster>
         <version.arm-oraclelinux-wls-dynamic-cluster>1.0.49</version.arm-oraclelinux-wls-dynamic-cluster>
         <!--  node versions  -->
         <version.arm-oraclelinux-wls-dynamic-cluster-addnode>1.0.7</version.arm-oraclelinux-wls-dynamic-cluster-addnode>

--- a/resources/azure-common.properties
+++ b/resources/azure-common.properties
@@ -46,4 +46,4 @@ azure.apiVersionForStorageFileService=2023-01-01
 # AzureAzCLI version
 azure.cli.version=2.53.0
 # AzurePowerShell version
-azure.powershell.version=11.6.0
+azure.powershell.version=11.5

--- a/resources/azure-common.properties
+++ b/resources/azure-common.properties
@@ -46,4 +46,4 @@ azure.apiVersionForStorageFileService=2023-01-01
 # AzureAzCLI version
 azure.cli.version=2.53.0
 # AzurePowerShell version
-azure.powershell.version=8.3
+azure.powershell.version=11.6.0

--- a/weblogic-azure-aks/src/main/bicep/mainTemplate.bicep
+++ b/weblogic-azure-aks/src/main/bicep/mainTemplate.bicep
@@ -370,7 +370,7 @@ module uamiDeployment 'modules/_uamiAndRoles.bicep' = {
 * Deploy ACR
 */
 module preAzureResourceDeployment './modules/_preDeployedAzureResources.bicep' = {
-  name: 'pre-azure-resources-deployment'
+  name: 'prerequisite-resources-deployment'
   params: {
     acrName: acrName
     acrResourceGroupName: acrResourceGroupName


### PR DESCRIPTION
This pull request upgrades PowerShell  version to `11.5`. 

Affected offer:
- WLS on AKS offer
- WLS configured cluster offer

Here are the most important changes:

1. Workflow updates:
   * [`.github/workflows/testWlsAksWithDependencyCreation.yml`](diffhunk://#diff-63b2fdbc9275aaf81cb48baa4d7c2d755d690d9b502ed7dc3636ec155b35ecceL150-R150): Increased the sleep duration from 1 minute to 2 minutes. This change allows more time for the preceding command to complete before the workflow continues.
   * [`.github/workflows/testWlsVmCluster.yml`](diffhunk://#diff-7d067565ae5cfee218770bf9de807122c30175b6aff9ff7dde9383bef8054be0R232-R233): Added a sleep duration of 2 minutes. This pause provides time for the preceding command to finish executing before the workflow progresses.

2. Version updates:
   * [`pom.xml`](diffhunk://#diff-9c5fb3d1b7e3b0f54bc5c4182965c4fe1f9023d449017cece3005d3f90e8e4d8L43-R47): Updated the `version.wls-on-aks-azure-marketplace` from 1.0.72 to 1.0.74 and `version.arm-oraclelinux-wls-cluster` from 1.0.650000 to 1.0.660000. These updates reflect the latest versions of the respective components.
   * [`resources/azure-common.properties`](diffhunk://#diff-95ef7df74966da9f26b91989c5a134cdb8549e1ca533df4d8e8504b09d35e649L49-R49): Updated the `azure.powershell.version` from 8.3 to 11.5. This change ensures the use of the latest version of Azure PowerShell.

3. Module renaming:
   * [`weblogic-azure-aks/src/main/bicep/mainTemplate.bicep`](diffhunk://#diff-9eaec954615fbe14ad7f6da8d53b31242e9a213bf900eb0f172998960b43c54cL373-R373): Renamed the module `pre-azure-resources-deployment` to `prerequisite-resources-deployment`. This new name provides a clearer understanding of the module's purpose.