### PR TITLE
Replace Azure Active Directory with Microsoft Entra ID.

### DIFF
--- a/weblogic-azure-vm/arm-oraclelinux-wls-admin/admin-ssl-post-deploy/src/main/scripts/configureCustomAdminSSL.sh
+++ b/weblogic-azure-vm/arm-oraclelinux-wls-admin/admin-ssl-post-deploy/src/main/scripts/configureCustomAdminSSL.sh
@@ -215,14 +215,14 @@ function importAADCertificateIntoWLSCustomTrustKeyStore()
             exit 1
         fi
 
-        # For SSL enabled causes AAD failure #225
+        # For SSL enabled causes Entra ID failure #225
         # ISSUE: https://github.com/wls-eng/arm-oraclelinux-wls/issues/225
 
-        echo "Importing AAD Certificate into WLS Custom Trust Key Store: "
+        echo "Importing Entra ID Certificate into WLS Custom Trust Key Store: "
 
         sudo ${JAVA_HOME}/bin/keytool -noprompt -import -trustcacerts -keystore $customSSLTrustKeyStoreFile -storepass $customTrustKeyStorePassPhrase -alias aadtrust -file ${addsCertificate} -storetype $customTrustKeyStoreType
     else
-        echo "customSSL not enabled. Not required to configure AAD for WebLogic Custom SSL"
+        echo "customSSL not enabled. Not required to configure Entra ID for WebLogic Custom SSL"
     fi
 }
 

--- a/weblogic-azure-vm/arm-oraclelinux-wls-admin/src/main/scripts/aadIntegration.sh
+++ b/weblogic-azure-vm/arm-oraclelinux-wls-admin/src/main/scripts/aadIntegration.sh
@@ -268,7 +268,7 @@ function importAADCertificate()
     # import the key to java security 
     . $oracleHome/oracle_common/common/bin/setWlstEnv.sh
 
-    # For AAD failure: exception happens when importing certificate to JDK 11.0.7
+    # For Entra ID failure: exception happens when importing certificate to JDK 11.0.7
     # ISSUE: https://github.com/wls-eng/arm-oraclelinux-wls/issues/109
     # JRE was removed since JDK 11.
     java_version=$(java -version 2>&1 | sed -n ';s/.* version "\(.*\)\.\(.*\)\..*"/\1\2/p;')
@@ -305,14 +305,14 @@ function importAADCertificateIntoWLSCustomTrustKeyStore()
            exit 1
         fi
 
-        # For SSL enabled causes AAD failure #225
+        # For SSL enabled causes Entra ID failure #225
         # ISSUE: https://github.com/wls-eng/arm-oraclelinux-wls/issues/225
 
-        echo "Importing AAD Certificate into WLS Custom Trust Key Store: "
+        echo "Importing Entra ID Certificate into WLS Custom Trust Key Store: "
 
         sudo ${JAVA_HOME}/bin/keytool -noprompt -import -trustcacerts -keystore ${DOMAIN_PATH}/${wlsDomainName}/keystores/trust.keystore -storepass ${customTrustKeyStorePassPhrase} -alias aadtrust -file ${addsCertificate} -storetype ${customTrustKeyStoreType}
     else
-        echo "customSSL not enabled. Not required to configure AAD for WebLogic Custom SSL"
+        echo "customSSL not enabled. Not required to configure Entra ID for WebLogic Custom SSL"
     fi
 }
 

--- a/weblogic-azure-vm/arm-oraclelinux-wls-cluster/addnode/src/main/scripts/addnode.sh
+++ b/weblogic-azure-vm/arm-oraclelinux-wls-cluster/addnode/src/main/scripts/addnode.sh
@@ -622,7 +622,7 @@ function importAADCertificate()
 {
     # import the key to java security 
     . $oracleHome/oracle_common/common/bin/setWlstEnv.sh
-    # For AAD failure: exception happens when importing certificate to JDK 11.0.7
+    # For Entra ID failure: exception happens when importing certificate to JDK 11.0.7
     # ISSUE: https://github.com/wls-eng/arm-oraclelinux-wls/issues/109
     # JRE was removed since JDK 11.
     java_version=$(java -version 2>&1 | sed -n ';s/.* version "\(.*\)\.\(.*\)\..*"/\1\2/p;')
@@ -658,14 +658,14 @@ function importAADCertificateIntoWLSCustomTrustKeyStore()
             exit 1
         fi
 
-        # For SSL enabled causes AAD failure #225
+        # For SSL enabled causes Entra ID failure #225
         # ISSUE: https://github.com/wls-eng/arm-oraclelinux-wls/issues/225
 
-        echo "Importing AAD Certificate into WLS Custom Trust Key Store: "
+        echo "Importing Entra ID Certificate into WLS Custom Trust Key Store: "
 
         sudo ${JAVA_HOME}/bin/keytool -noprompt -import -trustcacerts -keystore {KEYSTORE_PATH}/trust.keystore -storepass ${customTrustKeyStorePassPhrase} -alias aadtrust -file ${addsCertificate} -storetype ${customTrustKeyStoreType}
     else
-        echo "customSSL not enabled. Not required to configure AAD for WebLogic Custom SSL"
+        echo "customSSL not enabled. Not required to configure Entra ID for WebLogic Custom SSL"
     fi
 }
 

--- a/weblogic-azure-vm/arm-oraclelinux-wls-cluster/arm-oraclelinux-wls-cluster/src/main/scripts/aadIntegration.sh
+++ b/weblogic-azure-vm/arm-oraclelinux-wls-cluster/arm-oraclelinux-wls-cluster/src/main/scripts/aadIntegration.sh
@@ -1,7 +1,7 @@
 # Copyright (c) 2021, Oracle and/or its affiliates.
 # Licensed under the Universal Permissive License v 1.0 as shown at https://oss.oracle.com/licenses/upl.
 # Description
-# This script is to configure AAD for WebLogic cluster domain. 
+# This script is to configure Entra ID for WebLogic cluster domain. 
 
 
 #Function to output message to StdErr
@@ -304,7 +304,7 @@ function importAADCertificate()
 {
     # import the key to java security 
     . $oracleHome/oracle_common/common/bin/setWlstEnv.sh
-    # For AAD failure: exception happens when importing certificate to JDK 11.0.7
+    # For Entra ID failure: exception happens when importing certificate to JDK 11.0.7
     # ISSUE: https://github.com/wls-eng/arm-oraclelinux-wls/issues/109
     # JRE was removed since JDK 11.
     java_version=$(java -version 2>&1 | sed -n ';s/.* version "\(.*\)\.\(.*\)\..*"/\1\2/p;')
@@ -341,14 +341,14 @@ function importAADCertificateIntoWLSCustomTrustKeyStore()
            exit 1
         fi
 
-        # For SSL enabled causes AAD failure #225
+        # For SSL enabled causes Entra ID failure #225
         # ISSUE: https://github.com/wls-eng/arm-oraclelinux-wls/issues/225
 
-        echo "Importing AAD Certificate into WLS Custom Trust Key Store: "
+        echo "Importing Entra ID Certificate into WLS Custom Trust Key Store: "
 
         sudo ${JAVA_HOME}/bin/keytool -noprompt -import -trustcacerts -keystore ${DOMAIN_PATH}/${wlsDomainName}/keystores/trust.keystore -storepass ${customTrustKeyStorePassPhrase} -alias aadtrust -file ${addsCertificate} -storetype ${customTrustKeyStoreType}
     else
-        echo "customSSL not enabled. Not required to configure AAD for WebLogic Custom SSL"
+        echo "customSSL not enabled. Not required to configure Entra ID for WebLogic Custom SSL"
     fi
 }
 
@@ -414,7 +414,7 @@ EOF
     java $WLST_ARGS weblogic.WLST ${SCRIPT_PWD}/restart-managedServer.py 
 
     if [[ $? != 0 ]]; then
-    echo "Error : Fail to restart managed server to sync up aad configuration."
+    echo "Error : Fail to restart managed server to sync up Entra ID configuration."
     exit 1
     fi
 }

--- a/weblogic-azure-vm/arm-oraclelinux-wls-cluster/test/scripts/gen-parameters-aad-ag.sh
+++ b/weblogic-azure-vm/arm-oraclelinux-wls-cluster/test/scripts/gen-parameters-aad-ag.sh
@@ -3,7 +3,7 @@
 # Copyright (c) 2021, Oracle and/or its affiliates.
 # Licensed under the Universal Permissive License v 1.0 as shown at https://oss.oracle.com/licenses/upl.
 # Description
-# This script is to generate test parameters for AAD and appgeateway testing.
+# This script is to generate test parameters for Entra ID and appgeateway testing.
 
 #read arguments from stdin
 read parametersPath repoPath testbranchName keyVaultName keyVaultResourceGroup keyVaultSSLCertDataSecretName keyVaultSSLCertPasswordSecretName

--- a/weblogic-azure-vm/arm-oraclelinux-wls-cluster/test/scripts/gen-parameters-aad.sh
+++ b/weblogic-azure-vm/arm-oraclelinux-wls-cluster/test/scripts/gen-parameters-aad.sh
@@ -3,7 +3,7 @@
 # Copyright (c) 2021, Oracle and/or its affiliates.
 # Licensed under the Universal Permissive License v 1.0 as shown at https://oss.oracle.com/licenses/upl.
 # Description
-# This script is to generate test parameters for AAD testing.
+# This script is to generate test parameters for Entra ID testing.
 
 #read arguments from stdin
 read parametersPath repoPath testbranchName

--- a/weblogic-azure-vm/arm-oraclelinux-wls-cluster/test/scripts/gen-parameters-db-aad-ag.sh
+++ b/weblogic-azure-vm/arm-oraclelinux-wls-cluster/test/scripts/gen-parameters-db-aad-ag.sh
@@ -3,7 +3,7 @@
 # Copyright (c) 2021, Oracle and/or its affiliates.
 # Licensed under the Universal Permissive License v 1.0 as shown at https://oss.oracle.com/licenses/upl.
 # Description
-# This script is to generate test parameters for database datasource, AAD and Appgateway testing.
+# This script is to generate test parameters for database datasource, Entra ID and Appgateway testing.
 
 #read arguments from stdin
 read  parametersPath repoPath testbranchName keyVaultName keyVaultResourceGroup keyVaultSSLCertDataSecretName keyVaultSSLCertPasswordSecretName

--- a/weblogic-azure-vm/arm-oraclelinux-wls-cluster/test/scripts/gen-parameters-db-aad.sh
+++ b/weblogic-azure-vm/arm-oraclelinux-wls-cluster/test/scripts/gen-parameters-db-aad.sh
@@ -3,7 +3,7 @@
 # Copyright (c) 2021, Oracle and/or its affiliates.
 # Licensed under the Universal Permissive License v 1.0 as shown at https://oss.oracle.com/licenses/upl.
 # Description
-# This script is to generate test parameters for database datasource and AAD testing.
+# This script is to generate test parameters for database datasource and Entra ID testing.
 
 #read arguments from stdin
 read parametersPath repoPath testbranchName

--- a/weblogic-azure-vm/arm-oraclelinux-wls-dynamic-cluster/addnode/src/main/scripts/addNodeToDynamicCluster.sh
+++ b/weblogic-azure-vm/arm-oraclelinux-wls-dynamic-cluster/addnode/src/main/scripts/addNodeToDynamicCluster.sh
@@ -522,7 +522,7 @@ function importAADCertificate()
 {
     # import the key to java security 
     . $oracleHome/oracle_common/common/bin/setWlstEnv.sh
-    # For AAD failure: exception happens when importing certificate to JDK 11.0.7
+    # For Entra ID failure: exception happens when importing certificate to JDK 11.0.7
     # ISSUE: https://github.com/wls-eng/arm-oraclelinux-wls/issues/109
     # JRE was removed since JDK 11.
     java_version=$(java -version 2>&1 | sed -n ';s/.* version "\(.*\)\.\(.*\)\..*"/\1\2/p;')
@@ -558,14 +558,14 @@ function importAADCertificateIntoWLSCustomTrustKeyStore()
             exit 1
         fi
 
-        # For SSL enabled causes AAD failure #225
+        # For SSL enabled causes Entra ID failure #225
         # ISSUE: https://github.com/wls-eng/arm-oraclelinux-wls/issues/225
 
-        echo "Importing AAD Certificate into WLS Custom Trust Key Store: "
+        echo "Importing Entra ID Certificate into WLS Custom Trust Key Store: "
 
         sudo ${JAVA_HOME}/bin/keytool -noprompt -import -trustcacerts -keystore {KEYSTORE_PATH}/trust.keystore -storepass ${customTrustKeyStorePassPhrase} -alias aadtrust -file ${addsCertificate} -storetype ${customTrustKeyStoreType}
     else
-        echo "customSSL not enabled. Not required to configure AAD for WebLogic Custom SSL"
+        echo "customSSL not enabled. Not required to configure Entra ID for WebLogic Custom SSL"
     fi
 }
 

--- a/weblogic-azure-vm/arm-oraclelinux-wls-dynamic-cluster/arm-oraclelinux-wls-dynamic-cluster/src/main/scripts/aadIntegration.sh
+++ b/weblogic-azure-vm/arm-oraclelinux-wls-dynamic-cluster/arm-oraclelinux-wls-dynamic-cluster/src/main/scripts/aadIntegration.sh
@@ -308,7 +308,7 @@ function importAADCertificate()
 {
     # import the key to java security 
     . $oracleHome/oracle_common/common/bin/setWlstEnv.sh
-    # For AAD failure: exception happens when importing certificate to JDK 11.0.7
+    # For Entra ID failure: exception happens when importing certificate to JDK 11.0.7
     # ISSUE: https://github.com/wls-eng/arm-oraclelinux-wls/issues/109
     # JRE was removed since JDK 11.
     java_version=$(java -version 2>&1 | sed -n ';s/.* version "\(.*\)\.\(.*\)\..*"/\1\2/p;')
@@ -345,14 +345,14 @@ function importAADCertificateIntoWLSCustomTrustKeyStore()
            exit 1
         fi
 
-        # For SSL enabled causes AAD failure #225
+        # For SSL enabled causes Entra ID failure #225
         # ISSUE: https://github.com/wls-eng/arm-oraclelinux-wls/issues/225
 
-        echo "Importing AAD Certificate into WLS Custom Trust Key Store: "
+        echo "Importing Entra ID Certificate into WLS Custom Trust Key Store: "
 
         sudo ${JAVA_HOME}/bin/keytool -noprompt -import -trustcacerts -keystore ${DOMAIN_PATH}/${wlsDomainName}/keystores/trust.keystore -storepass ${customTrustKeyStorePassPhrase} -alias aadtrust -file ${addsCertificate} -storetype ${customTrustKeyStoreType}
     else
-        echo "customSSL not enabled. Not required to configure AAD for WebLogic Custom SSL"
+        echo "customSSL not enabled. Not required to configure Entra ID for WebLogic Custom SSL"
     fi
 }
 


### PR DESCRIPTION
This pull request primarily involves changes to the naming and comments in several scripts across the `weblogic-azure-vm` project. The changes are focused on replacing references to "AAD" (Azure Active Directory) with "Entra ID". This includes updates to function comments, echo statements, and error messages. 

Key changes include:

Changes in function comments and echo statements:

* `configureCustomAdminSSL.sh`, `aadIntegration.sh`, `addnode.sh`, `aadIntegration.sh`, `addNodeToDynamicCluster.sh`, `aadIntegration.sh`: Updated comments and echo statements in the `importAADCertificateIntoWLSCustomTrustKeyStore()` and `importAADCertificate()` functions to replace "AAD" with "Entra ID". [[1]](diffhunk://#diff-0c83bf143cfbec241b3086aadc987dae1359e1d86cb27127da14c041eb9b89b6L218-R225) [[2]](diffhunk://#diff-dd16a466a4a9f4f745c2abd7df9ccbd468f3d0a8470ffb51f24f372ba8179a25L271-R271) [[3]](diffhunk://#diff-dd16a466a4a9f4f745c2abd7df9ccbd468f3d0a8470ffb51f24f372ba8179a25L308-R315) [[4]](diffhunk://#diff-396ed419519c351f3c17526a4c22bb20d54af27943e076af72ad2ee99ef74a24L625-R625) [[5]](diffhunk://#diff-396ed419519c351f3c17526a4c22bb20d54af27943e076af72ad2ee99ef74a24L661-R668) [[6]](diffhunk://#diff-9638cf0d52e23796eb4d5f7a1c14cbb787750b682b3dbbd65c6e97e8de063307L307-R307) [[7]](diffhunk://#diff-9638cf0d52e23796eb4d5f7a1c14cbb787750b682b3dbbd65c6e97e8de063307L344-R351) [[8]](diffhunk://#diff-b5ba57baee4dc89cf03e371386be26afcadbd62108961fa42efec7a13b9303dfL525-R525) [[9]](diffhunk://#diff-b5ba57baee4dc89cf03e371386be26afcadbd62108961fa42efec7a13b9303dfL561-R568) [[10]](diffhunk://#diff-452da228b6c7e5c2e5a1674a1bb102a8b35349ee8692269063a6581ac0d0f59bL311-R311) [[11]](diffhunk://#diff-452da228b6c7e5c2e5a1674a1bb102a8b35349ee8692269063a6581ac0d0f59bL348-R355)

Changes in script descriptions:

* `aadIntegration.sh`, `gen-parameters-aad-ag.sh`, `gen-parameters-aad.sh`, `gen-parameters-db-aad-ag.sh`, `gen-parameters-db-aad.sh`: Updated script descriptions to replace "AAD" with "Entra ID". [[1]](diffhunk://#diff-9638cf0d52e23796eb4d5f7a1c14cbb787750b682b3dbbd65c6e97e8de063307L4-R4) [[2]](diffhunk://#diff-ce2defdb1ec364907bf0ed7c9335ccb6ac2587fc43d78cdaf2fc0c8052f69ccaL6-R6) [[3]](diffhunk://#diff-08da26806e40a5e77206cdbc242ecec1ac240aacc55a4ecd98f393191e6f9cb6L6-R6) [[4]](diffhunk://#diff-f311e1bd6574a5255de9be52b418ed8d22dd44b1b897348d1e4f9545781bec28L6-R6) [[5]](diffhunk://#diff-a45e755d6664797b9537fa3edb1c6be623d20b248beedfa37061f622d20a599dL6-R6)

Changes in error messages:

* [`aadIntegration.sh`](diffhunk://#diff-9638cf0d52e23796eb4d5f7a1c14cbb787750b682b3dbbd65c6e97e8de063307L417-R417): Updated error message in the `EOF` function to replace "aad" with "Entra ID".