### PR TITLE
Remove availability zone restriction as Reza suggests.

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -40,7 +40,7 @@
     <properties>    
         <!--  versions  start -->
         <!--  weblogic azure aks versions  -->
-        <version.wls-on-aks-azure-marketplace>1.0.78</version.wls-on-aks-azure-marketplace>
+        <version.wls-on-aks-azure-marketplace>1.0.79</version.wls-on-aks-azure-marketplace>
         <!--  weblogic azure vm versions  -->
         <version.arm-oraclelinux-wls>1.0.27</version.arm-oraclelinux-wls>
         <version.arm-oraclelinux-wls-admin>1.0.51</version.arm-oraclelinux-wls-admin>

--- a/weblogic-azure-aks/src/main/arm/createUiDefinition.json
+++ b/weblogic-azure-aks/src/main/arm/createUiDefinition.json
@@ -329,8 +329,6 @@
                                     "Standard_DS2_v2"
                                 ],
                                 "constraints": {
-                                    "numAvailabilityZonesRequired": 3,
-                                    "zone": "3",
                                     "excludedSizes": [
                                         "Standard_A0",
                                         "Standard_A1",

--- a/weblogic-azure-aks/src/main/arm/scripts/inline-scripts/validateParameters.sh
+++ b/weblogic-azure-aks/src/main/arm/scripts/inline-scripts/validateParameters.sh
@@ -598,7 +598,7 @@ function validate_appgateway_vnet() {
 
 function query_available_zones() {
   if [[ "${createAKSCluster,,}" == "true" ]]; then
-    outputAvailableZones=$(az vm list-skus -l ${location} --size ${aksAgentPoolVMSize} --zone true | jq '.[] | .locationInfo[] | .zones')
+    outputAvailableZones=$(az vm list-skus -l ${location} --size ${aksAgentPoolVMSize} --zone true | jq -c '.[] | .locationInfo[] | .zones')
   fi
 
   if [ -z "${outputAvailableZones}" ]; then  

--- a/weblogic-azure-aks/src/main/arm/scripts/inline-scripts/validateParameters.sh
+++ b/weblogic-azure-aks/src/main/arm/scripts/inline-scripts/validateParameters.sh
@@ -596,11 +596,24 @@ function validate_appgateway_vnet() {
   fi
 }
 
+function query_available_zones() {
+  if [[ "${createAKSCluster,,}" == "true" ]]; then
+    outputAvailableZones=$(az vm list-skus -l ${location} --size ${aksAgentPoolVMSize} --zone true | jq '.[] | .locationInfo[] | .zones')
+  fi
+
+  if [ -z "${outputAvailableZones}" ]; then  
+    outputAvailableZones="[]"
+  fi  
+
+  export outputAvailableZones="${outputAvailableZones}"
+}
+
 function output_result() {
   echo "AKS version: ${outputAksVersion}"
   result=$(jq -n -c \
     --arg aksVersion "$outputAksVersion" \
-    '{aksVersion: $aksVersion}')
+    --arg agentAvailabilityZones "${outputAvailableZones}" \
+    '{aksVersion: $aksVersion, agentAvailabilityZones: $agentAvailabilityZones}')
   echo "result is: $result"
   echo $result >$AZ_SCRIPTS_OUTPUT_PATH
 }
@@ -649,6 +662,8 @@ if [[ "${createAKSCluster,,}" != "true" ]]; then
 fi
 
 validate_appgateway_vnet
+
+query_available_zones
 
 output_result
 

--- a/weblogic-azure-aks/src/main/bicep/mainTemplate.bicep
+++ b/weblogic-azure-aks/src/main/bicep/mainTemplate.bicep
@@ -567,6 +567,7 @@ module wlsDomainDeployment 'modules/setupWebLogicCluster.bicep' = if (!enableCus
     aksClusterNamePrefix: aksClusterNamePrefix
     aksClusterRGName: aksClusterRGName
     aksClusterName: aksClusterName
+    aksAgentAvailabilityZones:validateInputs.outputs.aksAgentAvailabilityZones
     aksVersion: validateInputs.outputs.aksVersion
     appPackageUrls: appPackageUrls
     appReplicas: appReplicas
@@ -639,6 +640,7 @@ module wlsDomainWithCustomSSLDeployment 'modules/setupWebLogicCluster.bicep' = i
     aksClusterNamePrefix: aksClusterNamePrefix
     aksClusterRGName: aksClusterRGName
     aksClusterName: aksClusterName
+    aksAgentAvailabilityZones:validateInputs.outputs.aksAgentAvailabilityZones
     aksVersion: validateInputs.outputs.aksVersion
     appPackageUrls: appPackageUrls
     appReplicas: appReplicas

--- a/weblogic-azure-aks/src/main/bicep/modules/_azure-resoruces/_aks.bicep
+++ b/weblogic-azure-aks/src/main/bicep/modules/_azure-resoruces/_aks.bicep
@@ -7,6 +7,7 @@ param aciResourcePermissions bool = true
 param aciRetentionInDays int = 120
 @description('Pricing tier: PerGB2018 or legacy tiers (Free, Standalone, PerNode, Standard or Premium) which are not available to all customers.')
 param aciWorkspaceSku string = 'pergb2018'
+param agentAvailabilityZones array = []
 @maxLength(12)
 @minLength(1)
 @description('The name for this node pool. Node pool must contain only lowercase letters and numbers. For Linux node pools the name cannot be longer than 12 characters.')
@@ -27,11 +28,6 @@ param location string
 param utcValue string = utcNow()
 
 var const_aksAgentPoolOSDiskSizeGB = 128
-var const_aksAvailabilityZones = [
-  '1'
-  '2'
-  '3'
-]
 var name_aciWorkspace = 'Workspace-${guid(utcValue)}-${location}'
 // Generate a unique AKS name scoped to subscription. 
 var name_aksClusterNameForSV = '${aksClusterNamePrefix}${uniqueString(utcValue)}'
@@ -79,7 +75,7 @@ resource aksCluster 'Microsoft.ContainerService/managedClusters@${azure.apiVersi
         osDiskType: 'Managed'
         kubeletDiskType: 'OS'
         type: 'VirtualMachineScaleSets'
-        availabilityZones: const_aksAvailabilityZones
+        availabilityZones: agentAvailabilityZones
         mode: 'System'
         osType: 'Linux'
       }

--- a/weblogic-azure-aks/src/main/bicep/modules/_deployment-scripts/_ds-validate-parameters.bicep
+++ b/weblogic-azure-aks/src/main/bicep/modules/_deployment-scripts/_ds-validate-parameters.bicep
@@ -247,4 +247,4 @@ resource deploymentScript 'Microsoft.Resources/deploymentScripts@${azure.apiVers
 }
 
 output aksVersion string = deploymentScript.properties.outputs.aksVersion
-output aksAgentAvailabilityZones array = array(deploymentScript.properties.outputs.agentAvailabilityZones)
+output aksAgentAvailabilityZones array = json(deploymentScript.properties.outputs.agentAvailabilityZones)

--- a/weblogic-azure-aks/src/main/bicep/modules/_deployment-scripts/_ds-validate-parameters.bicep
+++ b/weblogic-azure-aks/src/main/bicep/modules/_deployment-scripts/_ds-validate-parameters.bicep
@@ -247,3 +247,4 @@ resource deploymentScript 'Microsoft.Resources/deploymentScripts@${azure.apiVers
 }
 
 output aksVersion string = deploymentScript.properties.outputs.aksVersion
+output aksAgentAvailabilityZones array = array(deploymentScript.properties.outputs.agentAvailabilityZones)

--- a/weblogic-azure-aks/src/main/bicep/modules/setupWebLogicCluster.bicep
+++ b/weblogic-azure-aks/src/main/bicep/modules/setupWebLogicCluster.bicep
@@ -29,6 +29,7 @@ param aciRetentionInDays int = 120
 param aciWorkspaceSku string = 'pergb2018'
 param acrName string = ''
 param acrResourceGroupName string = ''
+param aksAgentAvailabilityZones array = []
 @maxLength(12)
 @minLength(1)
 @description('The name for this node pool. Node pool must contain only lowercase letters and numbers. For Linux node pools the name cannot be longer than 12 characters.')
@@ -161,6 +162,7 @@ module aksClusterDeployment './_azure-resoruces/_aks.bicep' = if (createAKSClust
     aciResourcePermissions: aciResourcePermissions
     aciRetentionInDays: aciRetentionInDays
     aciWorkspaceSku: aciWorkspaceSku
+    agentAvailabilityZones: aksAgentAvailabilityZones
     aksAgentPoolName: aksAgentPoolName
     aksAgentPoolNodeCount: aksAgentPoolNodeCount
     aksAgentPoolNodeMaxCount: aksAgentPoolNodeMaxCount


### PR DESCRIPTION
Current offer requires VM size with 3 zones and causes no available VM size in some regions.

This PR is to remove the zone restriction and deploy AKS with best zone capability within the selected region.

We have to include the `availabilityZones` in the template, otherwise, the AKS cluster doesn't deploy in an availability zone. See [Azure Resource Manager templates and availability zones](https://learn.microsoft.com/en-us/azure/aks/availability-zones#azure-resource-manager-templates-and-availability-zones).