### PR TITLE
Upgrade WIT and AKS.

### DIFF
--- a/weblogic-azure-aks/src/main/resources/aks_well_tested_version.json
+++ b/weblogic-azure-aks/src/main/resources/aks_well_tested_version.json
@@ -1,6 +1,6 @@
 {
     "name": "Known-good version of Azure Kubernetes Service",
     "description": "This version is known to work for all the features of Azure WebLogic on AKS offer.",
-    "value": "1.26.6",
-    "testedDate": "2023-09-04"
+    "value": "1.28.10",
+    "testedDate": "2024-07-15"
 }

--- a/weblogic-azure-aks/src/main/resources/weblogic_tooling_family.json
+++ b/weblogic-azure-aks/src/main/resources/weblogic_tooling_family.json
@@ -18,9 +18,9 @@
         {
             "key": "WIT",
             "description": "Oracle WebLogic Image Tool",
-            "version": "1.12.1",
-            "downloadURL": "https://github.com/oracle/weblogic-image-tool/releases/download/release-1.12.1/imagetool.zip",
-            "testedDate": "2024-03-13"
+            "version": "1.13.2",
+            "downloadURL": "https://github.com/oracle/weblogic-image-tool/releases/download/release-1.13.2/imagetool.zip",
+            "testedDate": "2024-07-15"
         },
         {
             "key": "WME",


### PR DESCRIPTION
This pull request primarily updates versions and tested dates of certain software components in the `weblogic-azure-aks` project. The changes include updating the "Known-good version of Azure Kubernetes Service" and the version of "Oracle WebLogic Image Tool".

Updates to software components:

* [`weblogic-azure-aks/src/main/resources/aks_well_tested_version.json`](diffhunk://#diff-927c6f76e72f99b6a2390357bc05a661bbf3601a21791e9a1715c909957888efL4-R5): Updated the "Known-good version of Azure Kubernetes Service" from "1.26.6" to "1.28.10" and updated the tested date to "2024-07-15".
* [`weblogic-azure-aks/src/main/resources/weblogic_tooling_family.json`](diffhunk://#diff-e409cb1a2423fe4be41351f8a07b8249b9bd7bbd5a81d885be152e5f874f201fL21-R23): Updated the version of "Oracle WebLogic Image Tool" from "1.12.1" to "1.13.2", updated the download URL to the new version, and updated the tested date to "2024-07-15".