### PR TITLE
Modify ui definition to show the java option element

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -40,7 +40,7 @@
     <properties>    
         <!--  versions  start -->
         <!--  weblogic azure aks versions  -->
-        <version.wls-on-aks-azure-marketplace>1.0.82</version.wls-on-aks-azure-marketplace>
+        <version.wls-on-aks-azure-marketplace>1.0.83</version.wls-on-aks-azure-marketplace>
         <!--  weblogic azure vm versions  -->
         <version.arm-oraclelinux-wls>1.0.29</version.arm-oraclelinux-wls>
         <version.arm-oraclelinux-wls-admin>1.0.54</version.arm-oraclelinux-wls-admin>

--- a/weblogic-azure-aks/src/main/arm/createUiDefinition.json
+++ b/weblogic-azure-aks/src/main/arm/createUiDefinition.json
@@ -389,7 +389,7 @@
                             {
                                 "name": "aksNodeCount",
                                 "type": "Microsoft.Common.Slider",
-                                "min": "[add(1, div(add(12288, mul(if(empty(basics('basicsOptional').wlsClusterSize),5,basics('basicsOptional').wlsClusterSize), 1536)), first(filter(basics('basicsRequired').listVMSizes.value, (item) => equals(item.name, steps('section_aks').clusterInfo.nodeVMSizeSelector))).memoryInMB))]",
+                                "min": "[add(1, div(add(12288, mul(if(bool(basics('basicsOptional').basicsOptionalAcceptDefaults), basics('basicsOptional').wlsClusterSize, 5), 1536)), first(filter(basics('basicsRequired').listVMSizes.value, (item) => equals(item.name, steps('section_aks').clusterInfo.nodeVMSizeSelector))).memoryInMB))]",
                                 "defaultValue": 3,
                                 "max": 998,
                                 "label": "Minimum node count",


### PR DESCRIPTION
This pull request includes updates to version properties and a change to the logic for calculating the minimum node count in the Azure AKS configuration. The most important changes are:

Version updates:
* [`pom.xml`](diffhunk://#diff-9c5fb3d1b7e3b0f54bc5c4182965c4fe1f9023d449017cece3005d3f90e8e4d8L43-R43): Updated the version of `wls-on-aks-azure-marketplace` from `1.0.82` to `1.0.83`.

Logic improvement:
* [`weblogic-azure-aks/src/main/arm/createUiDefinition.json`](diffhunk://#diff-6942d0c3ae64307ad19b9c3cb12dbb240644dd47aefa4b3243c182ef0ec633acL392-R392): Modified the logic for the `min` property of `aksNodeCount` to use `basicsOptionalAcceptDefaults` for determining the cluster size.