### PR TITLE
Support re-deployment in the same resource group for single node offer

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -42,7 +42,7 @@
         <!--  weblogic azure aks versions  -->
         <version.wls-on-aks-azure-marketplace>1.0.87</version.wls-on-aks-azure-marketplace>
         <!--  weblogic azure vm versions  -->
-        <version.arm-oraclelinux-wls>1.0.30</version.arm-oraclelinux-wls>
+        <version.arm-oraclelinux-wls>1.0.31</version.arm-oraclelinux-wls>
         <version.arm-oraclelinux-wls-admin>1.0.55</version.arm-oraclelinux-wls-admin>
         <version.arm-oraclelinux-wls-cluster>1.0.710000</version.arm-oraclelinux-wls-cluster>
         <version.arm-oraclelinux-wls-dynamic-cluster>1.0.53</version.arm-oraclelinux-wls-dynamic-cluster>

--- a/resources/azure-common.properties
+++ b/resources/azure-common.properties
@@ -39,9 +39,9 @@ azure.apiVersionForDeployment=2023-07-01
 # Microsoft.Resources/tags
 azure.apiVersionForTags=2023-07-01
 # Microsoft.Storage/storageAccounts
-azure.apiVersionForStorage=2023-01-01
+azure.apiVersionForStorage=2023-05-01
 # Microsoft.Storage/storageAccounts/fileServices
-azure.apiVersionForStorageFileService=2023-01-01
+azure.apiVersionForStorageFileService=2023-05-01
 # Microsoft.Monitor/accounts
 azure.apiVersionForMonitorAccount=2023-04-03
 

--- a/weblogic-azure-vm/arm-oraclelinux-wls/src/main/arm/mainTemplate.json
+++ b/weblogic-azure-vm/arm-oraclelinux-wls/src/main/arm/mainTemplate.json
@@ -95,13 +95,9 @@
                 "description": "Bool value, if it's set to true, a system assigned managed identity will to be created for the VM(s)"
             }
         },
-      "utcValue": {
-         "type": "string",
-         "defaultValue": "[utcNow()]"
-      },
       "vmName": {
          "type": "string",
-         "defaultValue": "[concat('WeblogicServerVM',uniqueString(utcValue))]",
+         "defaultValue": "WeblogicServerVM",
          "metadata": {
             "description": "VM name."
          }
@@ -116,7 +112,7 @@
    },
    "variables": {
       "const_addressPrefix": "10.0.0.0/16",
-      "const_globalResourceNameSuffix": "[uniqueString(utcValue)]",
+      "const_globalResourceNameSuffix": "[uniqueString(parameters('guidValue'))]",
       "const_hyphen": "-",
       "const_imageOffer": "[concat('weblogic',variables('const_hyphen'), split(variables('name_linuxImageOfferSKU'),variables('const_hyphen'))[1],variables('const_hyphen'),split(variables('name_linuxImageOfferSKU'),variables('const_hyphen'))[2],variables('const_hyphen'),split(variables('name_linuxImageOfferSKU'),variables('const_hyphen'))[3],if(parameters('usePreviewImage'),'-preview',''))]",
       "const_imagePublisher": "oracle",
@@ -138,12 +134,13 @@
       "const_vmSize": "[parameters('vmSize')]",
       "name_linuxImageOfferSKU": "[first(split(parameters('skuUrnVersion'), ';'))]",
       "name_linuxImageVersion": "[last(split(parameters('skuUrnVersion'),';'))]",
-      "name_networkSecurityGroup": "[concat(parameters('dnsLabelPrefix'), '-nsg')]",
+      "name_networkSecurityGroup": "[concat(parameters('dnsLabelPrefix'), '-nsg_', variables('const_globalResourceNameSuffix'))]",
       "name_nic": "[concat('olvm_NIC_', variables('const_globalResourceNameSuffix'))]",
       "name_publicIPAddress": "[concat('olvm_PublicIP_', variables('const_globalResourceNameSuffix'))]",
       "name_storageAccount": "[concat('olvmstg', variables('const_globalResourceNameSuffix'))]",
       "name_subnet": "Subnet",
-      "name_virtualNetwork": "[concat('olvm_VNET', variables('const_globalResourceNameSuffix'))]",
+      "name_virtualNetwork": "[concat('olvm_VNET_', variables('const_globalResourceNameSuffix'))]",
+      "name_vmName": "[concat(parameters('vmName'), variables('const_globalResourceNameSuffix'))]",
       "ref_networkSecurityGroup": "[resourceId('Microsoft.Network/networkSecurityGroups', variables('name_networkSecurityGroup'))]",
       "ref_subnet": "[resourceId('Microsoft.Network/virtualNetworks/subnets', variables('name_virtualNetwork'), variables('name_subnet'))]"
    },
@@ -290,7 +287,7 @@
                }
             ],
             "dnsSettings": {
-               "internalDnsNameLabel": "[parameters('vmName')]"
+               "internalDnsNameLabel": "[variables('name_vmName')]"
             }
          }
       },
@@ -298,7 +295,7 @@
          "apiVersion": "${azure.apiVersionForVirtualMachines}",
          "type": "Microsoft.Compute/virtualMachines",
          "tags": "[funcTags.tagsFilter(parameters('tagsByResource'), '${identifier.virtualMachines}')]",
-         "name": "[parameters('vmName')]",
+         "name": "[variables('name_vmName')]",
          "location": "[parameters('location')]",
          "dependsOn": [
             "[resourceId('Microsoft.Storage/storageAccounts/', variables('name_storageAccount'))]",
@@ -310,7 +307,7 @@
                "vmSize": "[variables('const_vmSize')]"
             },
             "osProfile": {
-               "computerName": "[parameters('vmName')]",
+               "computerName": "[variables('name_vmName')]",
                "adminUsername": "[parameters('adminUsername')]",
                "adminPassword": "[parameters('adminPasswordOrKey')]",
                "linuxConfiguration": "[if(equals(parameters('authenticationType'), 'password'), json('null'), variables('const_linuxConfiguration'))]"
@@ -355,7 +352,7 @@
          "type": "Microsoft.Resources/deployments",
          "tags": "[funcTags.tagsFilter(parameters('tagsByResource'),'${identifier.resourcesDeployment}')]",
          "dependsOn": [
-            "[resourceId('Microsoft.Compute/virtualMachines/', parameters('vmName'))]"
+            "[resourceId('Microsoft.Compute/virtualMachines/', variables('name_vmName'))]"
          ],
          "properties": {
             "mode": "Incremental",
@@ -373,7 +370,7 @@
          "tags": "[funcTags.tagsFilter(parameters('tagsByResource'),'${identifier.resourcesDeployment}')]",
          "condition": "[if(contains(variables('name_linuxImageOfferSKU'), 'owls-141100-jdk11-ol91'), bool('true'), bool('false'))]",
          "dependsOn": [
-            "[resourceId('Microsoft.Compute/virtualMachines/', parameters('vmName'))]"
+            "[resourceId('Microsoft.Compute/virtualMachines/', variables('name_vmName'))]"
          ],
          "properties": {
             "mode": "Incremental",
@@ -392,7 +389,7 @@
          "tags": "[funcTags.tagsFilter(parameters('tagsByResource'),'${identifier.resourcesDeployment}')]",
          "condition": "[if(contains(variables('name_linuxImageOfferSKU'), 'owls-141100-jdk11-ol87'), bool('true'), bool('false'))]",
          "dependsOn": [
-            "[resourceId('Microsoft.Compute/virtualMachines/', parameters('vmName'))]"
+            "[resourceId('Microsoft.Compute/virtualMachines/', variables('name_vmName'))]"
          ],
          "properties": {
             "mode": "Incremental",
@@ -411,7 +408,7 @@
          "tags": "[funcTags.tagsFilter(parameters('tagsByResource'),'${identifier.resourcesDeployment}')]",
          "condition": "[if(contains(variables('name_linuxImageOfferSKU'), 'owls-141100-jdk8-ol91'), bool('true'), bool('false'))]",
          "dependsOn": [
-            "[resourceId('Microsoft.Compute/virtualMachines/', parameters('vmName'))]"
+            "[resourceId('Microsoft.Compute/virtualMachines/', variables('name_vmName'))]"
          ],
          "properties": {
             "mode": "Incremental",
@@ -430,7 +427,7 @@
          "tags": "[funcTags.tagsFilter(parameters('tagsByResource'),'${identifier.resourcesDeployment}')]",
          "condition": "[if(contains(variables('name_linuxImageOfferSKU'), 'owls-141100-jdk8-ol87'), bool('true'), bool('false'))]",
          "dependsOn": [
-            "[resourceId('Microsoft.Compute/virtualMachines/', parameters('vmName'))]"
+            "[resourceId('Microsoft.Compute/virtualMachines/', variables('name_vmName'))]"
          ],
          "properties": {
             "mode": "Incremental",
@@ -449,7 +446,7 @@
          "tags": "[funcTags.tagsFilter(parameters('tagsByResource'),'${identifier.resourcesDeployment}')]",
          "condition": "[if(contains(variables('name_linuxImageOfferSKU'), 'owls-122140-jdk8-ol91'), bool('true'), bool('false'))]",
          "dependsOn": [
-            "[resourceId('Microsoft.Compute/virtualMachines/', parameters('vmName'))]"
+            "[resourceId('Microsoft.Compute/virtualMachines/', variables('name_vmName'))]"
          ],
          "properties": {
             "mode": "Incremental",
@@ -468,7 +465,7 @@
          "tags": "[funcTags.tagsFilter(parameters('tagsByResource'),'${identifier.resourcesDeployment}')]",
          "condition": "[if(contains(variables('name_linuxImageOfferSKU'), 'owls-122140-jdk8-ol87'), bool('true'), bool('false'))]",
          "dependsOn": [
-            "[resourceId('Microsoft.Compute/virtualMachines/', parameters('vmName'))]"
+            "[resourceId('Microsoft.Compute/virtualMachines/', variables('name_vmName'))]"
          ],
          "properties": {
             "mode": "Incremental",
@@ -487,7 +484,7 @@
          "tags": "[funcTags.tagsFilter(parameters('tagsByResource'),'${identifier.resourcesDeployment}')]",
          "condition": "[if(contains(variables('name_linuxImageOfferSKU'), 'from.owls-122140-jdk8-ol76'), bool('true'), bool('false'))]",
          "dependsOn": [
-            "[resourceId('Microsoft.Compute/virtualMachines/', parameters('vmName'))]"
+            "[resourceId('Microsoft.Compute/virtualMachines/', variables('name_vmName'))]"
          ],
          "properties": {
             "mode": "Incremental",
@@ -506,7 +503,7 @@
          "tags": "[funcTags.tagsFilter(parameters('tagsByResource'),'${identifier.resourcesDeployment}')]",
          "condition": "[if(contains(variables('name_linuxImageOfferSKU'), 'owls-141100-jdk8-ol76'), bool('true'), bool('false'))]",
          "dependsOn": [
-            "[resourceId('Microsoft.Compute/virtualMachines/', parameters('vmName'))]"
+            "[resourceId('Microsoft.Compute/virtualMachines/', variables('name_vmName'))]"
          ],
          "properties": {
             "mode": "Incremental",
@@ -525,7 +522,7 @@
          "tags": "[funcTags.tagsFilter(parameters('tagsByResource'),'${identifier.resourcesDeployment}')]",
          "condition": "[if(contains(variables('name_linuxImageOfferSKU'), 'owls-141100-jdk11-ol76'), bool('true'), bool('false'))]",
          "dependsOn": [
-            "[resourceId('Microsoft.Compute/virtualMachines/', parameters('vmName'))]"
+            "[resourceId('Microsoft.Compute/virtualMachines/', variables('name_vmName'))]"
          ],
          "properties": {
             "mode": "Incremental",
@@ -544,7 +541,7 @@
          "tags": "[funcTags.tagsFilter(parameters('tagsByResource'),'${identifier.resourcesDeployment}')]",
          "condition": "[if(contains(variables('name_linuxImageOfferSKU'), 'owls-122140-jdk8-rhel87'), bool('true'), bool('false'))]",
          "dependsOn": [
-            "[resourceId('Microsoft.Compute/virtualMachines/', parameters('vmName'))]"
+            "[resourceId('Microsoft.Compute/virtualMachines/', variables('name_vmName'))]"
          ],
          "properties": {
             "mode": "Incremental",
@@ -563,7 +560,7 @@
          "tags": "[funcTags.tagsFilter(parameters('tagsByResource'),'${identifier.resourcesDeployment}')]",
          "condition": "[if(contains(variables('name_linuxImageOfferSKU'), 'owls-141100-jdk8-rhel87'), bool('true'), bool('false'))]",
          "dependsOn": [
-            "[resourceId('Microsoft.Compute/virtualMachines/', parameters('vmName'))]"
+            "[resourceId('Microsoft.Compute/virtualMachines/', variables('name_vmName'))]"
          ],
          "properties": {
             "mode": "Incremental",
@@ -582,7 +579,7 @@
          "tags": "[funcTags.tagsFilter(parameters('tagsByResource'),'${identifier.resourcesDeployment}')]",
          "condition": "[if(contains(variables('name_linuxImageOfferSKU'), 'owls-141100-jdk11-rhel87'), bool('true'), bool('false'))]",
          "dependsOn": [
-            "[resourceId('Microsoft.Compute/virtualMachines/', parameters('vmName'))]"
+            "[resourceId('Microsoft.Compute/virtualMachines/', variables('name_vmName'))]"
          ],
          "properties": {
             "mode": "Incremental",
@@ -601,7 +598,7 @@
          "tags": "[funcTags.tagsFilter(parameters('tagsByResource'),'${identifier.resourcesDeployment}')]",
          "condition": "[if(contains(variables('name_linuxImageOfferSKU'), 'owls-122140-jdk8-rhel76'), bool('true'), bool('false'))]",
          "dependsOn": [
-            "[resourceId('Microsoft.Compute/virtualMachines/', parameters('vmName'))]"
+            "[resourceId('Microsoft.Compute/virtualMachines/', variables('name_vmName'))]"
          ],
          "properties": {
             "mode": "Incremental",
@@ -620,7 +617,7 @@
          "tags": "[funcTags.tagsFilter(parameters('tagsByResource'),'${identifier.resourcesDeployment}')]",
          "condition": "[if(contains(variables('name_linuxImageOfferSKU'), 'owls-141100-jdk8-rhel76'), bool('true'), bool('false'))]",
          "dependsOn": [
-            "[resourceId('Microsoft.Compute/virtualMachines/', parameters('vmName'))]"
+            "[resourceId('Microsoft.Compute/virtualMachines/', variables('name_vmName'))]"
          ],
          "properties": {
             "mode": "Incremental",
@@ -639,7 +636,7 @@
          "tags": "[funcTags.tagsFilter(parameters('tagsByResource'),'${identifier.resourcesDeployment}')]",
          "condition": "[if(contains(variables('name_linuxImageOfferSKU'), 'owls-141100-jdk11-rhel76'), bool('true'), bool('false'))]",
          "dependsOn": [
-            "[resourceId('Microsoft.Compute/virtualMachines/', parameters('vmName'))]"
+            "[resourceId('Microsoft.Compute/virtualMachines/', variables('name_vmName'))]"
          ],
          "properties": {
             "mode": "Incremental",

--- a/weblogic-azure-vm/arm-oraclelinux-wls/src/main/arm/mainTemplate.json
+++ b/weblogic-azure-vm/arm-oraclelinux-wls/src/main/arm/mainTemplate.json
@@ -95,9 +95,13 @@
                 "description": "Bool value, if it's set to true, a system assigned managed identity will to be created for the VM(s)"
             }
         },
+      "utcValue": {
+         "type": "string",
+         "defaultValue": "[utcNow()]"
+      },
       "vmName": {
          "type": "string",
-         "defaultValue": "WeblogicServerVM",
+         "defaultValue": "[concat('WeblogicServerVM',uniqueString(utcValue))]",
          "metadata": {
             "description": "VM name."
          }
@@ -112,6 +116,7 @@
    },
    "variables": {
       "const_addressPrefix": "10.0.0.0/16",
+      "const_globalResourceNameSuffix": "[uniqueString(utcValue)]",
       "const_hyphen": "-",
       "const_imageOffer": "[concat('weblogic',variables('const_hyphen'), split(variables('name_linuxImageOfferSKU'),variables('const_hyphen'))[1],variables('const_hyphen'),split(variables('name_linuxImageOfferSKU'),variables('const_hyphen'))[2],variables('const_hyphen'),split(variables('name_linuxImageOfferSKU'),variables('const_hyphen'))[3],if(parameters('usePreviewImage'),'-preview',''))]",
       "const_imagePublisher": "oracle",
@@ -134,11 +139,11 @@
       "name_linuxImageOfferSKU": "[first(split(parameters('skuUrnVersion'), ';'))]",
       "name_linuxImageVersion": "[last(split(parameters('skuUrnVersion'),';'))]",
       "name_networkSecurityGroup": "[concat(parameters('dnsLabelPrefix'), '-nsg')]",
-      "name_nic": "olvm_NIC",
-      "name_publicIPAddress": "olvm_PublicIP",
-      "name_storageAccount": "[concat(take(replace(parameters('guidValue'),'-',''),6),'olvm')]",
+      "name_nic": "[concat('olvm_NIC_', variables('const_globalResourceNameSuffix'))]",
+      "name_publicIPAddress": "[concat('olvm_PublicIP_', variables('const_globalResourceNameSuffix'))]",
+      "name_storageAccount": "[concat('olvmstg', variables('const_globalResourceNameSuffix'))]",
       "name_subnet": "Subnet",
-      "name_virtualNetwork": "olvm_VNET",
+      "name_virtualNetwork": "[concat('olvm_VNET', variables('const_globalResourceNameSuffix'))]",
       "ref_networkSecurityGroup": "[resourceId('Microsoft.Network/networkSecurityGroups', variables('name_networkSecurityGroup'))]",
       "ref_subnet": "[resourceId('Microsoft.Network/virtualNetworks/subnets', variables('name_virtualNetwork'), variables('name_subnet'))]"
    },


### PR DESCRIPTION
This pull request includes several updates and improvements to versioning and naming conventions in the `weblogic-azure-vm` project. The most important changes include updating version numbers in configuration files and modifying naming conventions for resources in the ARM template to ensure uniqueness.

### Version Updates:
* [`pom.xml`](diffhunk://#diff-9c5fb3d1b7e3b0f54bc5c4182965c4fe1f9023d449017cece3005d3f90e8e4d8L45-R45): Updated `version.arm-oraclelinux-wls` from `1.0.30` to `1.0.31`.
* [`resources/azure-common.properties`](diffhunk://#diff-95ef7df74966da9f26b91989c5a134cdb8549e1ca533df4d8e8504b09d35e649L42-R44): Updated `azure.apiVersionForStorage` and `azure.apiVersionForStorageFileService` to `2023-05-01`.

### Naming Conventions:
* `weblogic-azure-vm/arm-oraclelinux-wls/src/main/arm/mainTemplate.json`: 
  * Added `const_globalResourceNameSuffix` variable for unique resource naming.
  * Updated resource names to include `const_globalResourceNameSuffix` for `networkSecurityGroup`, `nic`, `publicIPAddress`, `storageAccount`, `virtualNetwork`, and `vmName`.
  * Modified references to use `variables('name_vmName')` instead of `parameters('vmName')` for consistency. [[1]](diffhunk://#diff-1a949a049881658389dc90478725ebe2db92b5f743f09924fc09ffdd891a2047L288-R298) [[2]](diffhunk://#diff-1a949a049881658389dc90478725ebe2db92b5f743f09924fc09ffdd891a2047L308-R310) [[3]](diffhunk://#diff-1a949a049881658389dc90478725ebe2db92b5f743f09924fc09ffdd891a2047L353-R355) [[4]](diffhunk://#diff-1a949a049881658389dc90478725ebe2db92b5f743f09924fc09ffdd891a2047L371-R373) [[5]](diffhunk://#diff-1a949a049881658389dc90478725ebe2db92b5f743f09924fc09ffdd891a2047L390-R392) [[6]](diffhunk://#diff-1a949a049881658389dc90478725ebe2db92b5f743f09924fc09ffdd891a2047L409-R411) [[7]](diffhunk://#diff-1a949a049881658389dc90478725ebe2db92b5f743f09924fc09ffdd891a2047L428-R430) [[8]](diffhunk://#diff-1a949a049881658389dc90478725ebe2db92b5f743f09924fc09ffdd891a2047L447-R449) [[9]](diffhunk://#diff-1a949a049881658389dc90478725ebe2db92b5f743f09924fc09ffdd891a2047L466-R468) [[10]](diffhunk://#diff-1a949a049881658389dc90478725ebe2db92b5f743f09924fc09ffdd891a2047L485-R487) [[11]](diffhunk://#diff-1a949a049881658389dc90478725ebe2db92b5f743f09924fc09ffdd891a2047L504-R506) [[12]](diffhunk://#diff-1a949a049881658389dc90478725ebe2db92b5f743f09924fc09ffdd891a2047L523-R525) [[13]](diffhunk://#diff-1a949a049881658389dc90478725ebe2db92b5f743f09924fc09ffdd891a2047L542-R544) [[14]](diffhunk://#diff-1a949a049881658389dc90478725ebe2db92b5f743f09924fc09ffdd891a2047L561-R563) [[15]](diffhunk://#diff-1a949a049881658389dc90478725ebe2db92b5f743f09924fc09ffdd891a2047L580-R582) [[16]](diffhunk://#diff-1a949a049881658389dc90478725ebe2db92b5f743f09924fc09ffdd891a2047L599-R601) [[17]](diffhunk://#diff-1a949a049881658389dc90478725ebe2db92b5f743f09924fc09ffdd891a2047L618-R620) [[18]](diffhunk://#diff-1a949a049881658389dc90478725ebe2db92b5f743f09924fc09ffdd891a2047L637-R639)