### PR TITLE
Update credential scripts to use default repository context for GitHub CLI commands

### DIFF
--- a/.github/resource/azure-credential-setup-wls-aks.sh
+++ b/.github/resource/azure-credential-setup-wls-aks.sh
@@ -14,7 +14,7 @@ SP_ID=$( az ad sp list --display-name $SERVICE_PRINCIPAL_NAME_WLS_AKS --query \[
 az role assignment create --assignee ${SP_ID} --scope="/subscriptions/${SUBSCRIPTION_ID}" --role "User Access Administrator"
 
 ## Set the Azure Credentials as a secret in the repository
-gh secret set "AZURE_CREDENTIALS" -b"${AZURE_CREDENTIALS}"
-gh variable set "SERVICE_PRINCIPAL_NAME_WLS_AKS" -b"${SERVICE_PRINCIPAL_NAME_WLS_AKS}"
+gh secret --repo $(gh repo set-default --view) set "AZURE_CREDENTIALS" -b"${AZURE_CREDENTIALS}"
+gh variable --repo $(gh repo set-default --view) set "SERVICE_PRINCIPAL_NAME_WLS_AKS" -b"${SERVICE_PRINCIPAL_NAME_WLS_AKS}"
 
 echo "Execute azure-credential-setup.sh - End--------------------------------------------"

--- a/.github/resource/azure-credential-setup-wls-vm.sh
+++ b/.github/resource/azure-credential-setup-wls-vm.sh
@@ -13,7 +13,7 @@ SERVICE_PRINCIPAL=$(az ad sp create-for-rbac --name ${SERVICE_PRINCIPAL_NAME_WLS
 AZURE_CREDENTIALS=$(echo $SERVICE_PRINCIPAL | base64 -d)
 
 ## Set the Azure Credentials as a secret in the repository
-gh secret set "AZURE_CREDENTIALS" -b"${AZURE_CREDENTIALS}"
-gh variable set "SERVICE_PRINCIPAL_NAME_WLS_VM" -b"${SERVICE_PRINCIPAL_NAME_WLS_VM}"
+gh secret --repo $(gh repo set-default --view) set "AZURE_CREDENTIALS" -b"${AZURE_CREDENTIALS}"
+gh variable --repo $(gh repo set-default --view) set "SERVICE_PRINCIPAL_NAME_WLS_VM" -b"${SERVICE_PRINCIPAL_NAME_WLS_VM}"
 
 echo "Execute azure-credential-setup.sh - End--------------------------------------------"

--- a/.github/resource/azure-credential-teardown-wls-aks.sh
+++ b/.github/resource/azure-credential-teardown-wls-aks.sh
@@ -4,8 +4,8 @@ set -Eeuo pipefail
 
 echo "Execute azure-credential-teardown.sh - Start------------------------------------------"
 
-gh secret delete "AZURE_CREDENTIALS"
-SERVICE_PRINCIPAL_NAME_WLS_AKS=$(gh variable get "SERVICE_PRINCIPAL_NAME_WLS_AKS")
+gh secret --repo $(gh repo set-default --view) delete "AZURE_CREDENTIALS"
+SERVICE_PRINCIPAL_NAME_WLS_AKS=$(gh variable --repo $(gh repo set-default --view) get "SERVICE_PRINCIPAL_NAME_WLS_AKS")
 az ad sp delete --id $(az ad sp list --display-name $SERVICE_PRINCIPAL_NAME_WLS_AKS --query "[].appId" -o tsv| tr -d '\r\n')
 
 echo "Execute azure-credential-teardown.sh - End--------------------------------------------"

--- a/.github/resource/azure-credential-teardown-wls-vm.sh
+++ b/.github/resource/azure-credential-teardown-wls-vm.sh
@@ -4,8 +4,8 @@ set -Eeuo pipefail
 
 echo "Execute azure-credential-teardown.sh - Start------------------------------------------"
 
-gh secret delete "AZURE_CREDENTIALS"
-SERVICE_PRINCIPAL_NAME_WLS_VM=$(gh variable get "SERVICE_PRINCIPAL_NAME_WLS_VM")
+gh secret --repo $(gh repo set-default --view) delete "AZURE_CREDENTIALS"
+SERVICE_PRINCIPAL_NAME_WLS_VM=$(gh variable --repo $(gh repo set-default --view) get "SERVICE_PRINCIPAL_NAME_WLS_VM")
 az ad sp delete --id $(az ad sp list --display-name $SERVICE_PRINCIPAL_NAME_WLS_VM --query "[].appId" -o tsv| tr -d '\r\n')
 
 echo "Execute azure-credential-teardown.sh - End--------------------------------------------"

--- a/.github/resource/credentials-params-setup.sh
+++ b/.github/resource/credentials-params-setup.sh
@@ -40,7 +40,7 @@ set_values() {
     yq eval -o=json '.[]' "$param_file" | jq -c '.' | while read -r line; do
         name=$(echo "$line" | jq -r '.name')
         value=$(echo "$line" | jq -r '.value')
-        gh secret set "$name" -b"${value}"
+        gh secret --repo $(gh repo set-default --view) set "$name" -b"${value}"
     done
 }
 

--- a/.github/resource/credentials-params-teardown.sh
+++ b/.github/resource/credentials-params-teardown.sh
@@ -7,7 +7,7 @@ echo "teardown-credentials.sh - Start"
 yq eval -o=json '.[]' "$param_file" | jq -c '.' | while read -r line; do
     name=$(echo "$line" | jq -r '.name')
     value=$(echo "$line" | jq -r '.value')
-    gh secret --repo $(gh repo set-default --view) remove "$name"
+    gh secret --repo $(gh repo set-default --view) delete "$name"
 done
 
 echo "teardown-credentials.sh - Finish"

--- a/.github/resource/credentials-params-teardown.sh
+++ b/.github/resource/credentials-params-teardown.sh
@@ -7,7 +7,7 @@ echo "teardown-credentials.sh - Start"
 yq eval -o=json '.[]' "$param_file" | jq -c '.' | while read -r line; do
     name=$(echo "$line" | jq -r '.name')
     value=$(echo "$line" | jq -r '.value')
-    gh secret remove "$name"
+    gh secret --repo $(gh repo set-default --view) remove "$name"
 done
 
 echo "teardown-credentials.sh - Finish"

--- a/.github/resource/pre-check.sh
+++ b/.github/resource/pre-check.sh
@@ -63,3 +63,6 @@ fi
 echo "6/6...You are logged in to Azure CLI (az)."
 
 echo "Checking progress completed..."
+
+echo "Select default repository for this project"
+gh repo set-default


### PR DESCRIPTION
As title.


## Reference
`gh secret remove`  equals `gh secret delete`
<img width="585" alt="image" src="https://github.com/user-attachments/assets/a4f693f4-2c8b-41c8-ad0f-26e15ae03678" />

