### PR TITLE
fix arm-ttk validation errors in bicep files for WebLogic on AKS offer

### DIFF
--- a/resources/azure-common.properties
+++ b/resources/azure-common.properties
@@ -14,7 +14,7 @@ azure.apiVersionForRoleDefinitions=2022-04-01
 # Microsoft.ContainerRegistry/registries
 azure.apiVersionForContainerRegistries=2023-07-01
 # Microsoft.ContainerService/managedClusters
-azure.apiVersionForManagedClusters=2023-08-01
+azure.apiVersionForManagedClusters=2023-10-01
 # Microsoft.Compute/availabilitySets
 azure.apiVersionForAvailabilitySets=2024-11-01
 # Microsoft.Compute/virtualMachines

--- a/weblogic-azure-aks/src/main/bicep/mainTemplate.bicep
+++ b/weblogic-azure-aks/src/main/bicep/mainTemplate.bicep
@@ -59,8 +59,10 @@ param appGatewayCertificateOption string = 'haveCert'
 @description('Public IP Name for the Application Gateway')
 param appGatewayPublicIPAddressName string = 'gwip'
 @description('The one-line, base64 string of the backend SSL root certificate data.')
+@secure()
 param appGatewaySSLBackendRootCertData string = newGuid()
 @description('The one-line, base64 string of the SSL certificate data.')
+@secure()
 param appGatewaySSLCertData string = newGuid()
 @secure()
 @description('The value of the password for the SSL Certificate')

--- a/weblogic-azure-aks/src/main/bicep/modules/_appGateway.bicep
+++ b/weblogic-azure-aks/src/main/bicep/modules/_appGateway.bicep
@@ -29,7 +29,6 @@ param sslCertificateDeploymentName string
 @secure()
 param sslCertPswData string
 param trustedRootCertificateDeploymentName string
-@secure()
 param vnetForApplicationGateway object
 param vnetRGNameForApplicationGateway string
 @description('${label.tagsLabel}')

--- a/weblogic-azure-aks/src/main/bicep/modules/_azure-resoruces/_vnetAppGateway.bicep
+++ b/weblogic-azure-aks/src/main/bicep/modules/_azure-resoruces/_vnetAppGateway.bicep
@@ -21,7 +21,6 @@ param vnetForApplicationGateway object = {
 }
 @description('${label.tagsLabel}')
 param tagsByResource object
-param utcValue string = utcNow()
 
 var const_subnetAddressPrefixes = vnetForApplicationGateway.subnets.gatewaySubnet.addressPrefix
 var const_vnetAddressPrefixes = vnetForApplicationGateway.addressPrefixes

--- a/weblogic-azure-aks/src/main/bicep/modules/_deployment-scripts/_ds-validate-parameters.bicep
+++ b/weblogic-azure-aks/src/main/bicep/modules/_deployment-scripts/_ds-validate-parameters.bicep
@@ -10,6 +10,7 @@ param aksClusterRGName string
 param aksClusterName string
 param aksVersion string = 'default'
 param appGatewayCertificateOption string
+@secure()
 param appGatewaySSLCertData string
 @secure()
 param appGatewaySSLCertPassword string

--- a/weblogic-azure-aks/src/main/bicep/modules/_setupPasswordlessDBConnection.bicep
+++ b/weblogic-azure-aks/src/main/bicep/modules/_setupPasswordlessDBConnection.bicep
@@ -142,7 +142,7 @@ module configDataSource '_deployment-scripts/_ds-datasource-connection.bicep' = 
     dbConfigurationType: dbConfigurationType
     dbGlobalTranPro: dbGlobalTranPro
     dbUser: dbUser
-    dsConnectionURL: format('{0}{4}{1}{5}{2}={3}', const_connectionString, name_jdbcPlugins[databaseType], array_msiClientId[databaseType], reference(items(dbIdentity.userAssignedIdentities)[0].key, const_identityAPIVersion, 'full').properties.clientId, array_urlJoiner[databaseType], array_paramJoiner[databaseType])
+    dsConnectionURL: uri(uri(const_connectionString, '${array_urlJoiner[databaseType]}${name_jdbcPlugins[databaseType]}'), '${array_paramJoiner[databaseType]}${array_msiClientId[databaseType]}=${reference(items(dbIdentity.userAssignedIdentities)[0].key, const_identityAPIVersion, 'full').properties.clientId}')
     enablePswlessConnection: true
     identity: identity
     jdbcDataSourceName: jdbcDataSourceName


### PR DESCRIPTION
This issue fixes the arm-ttk validation errors in bicep files for WebLogic on AKS offer

Following validation errors are fixed:

API version validation error: 
    [-] apiVersions Should Be Recent (2041 ms)
        Api versions must be the latest or under 2 years old (730 days) - API version 2023-08-01 of Microsoft.ContainerService/managedClusters is 791 days old
Line: 13408, Column: 8
        Valid Api Versions:
        2023-10-01
        2023-10-02-preview

 NestedTemplate vnet-application-gateway [ Lines 2427 - 4533 ]
    [-] Parameters Must Be Referenced (1772 ms)
        Unreferenced parameter: utcValue Line: 2469, Column: 22

Parameter Types Should Be Consistent
    [-] Parameter Types Should Be Consistent (2347 ms)
        Type Mismatch: Parameter 'appGatewaySSLCertData' in nested template 'validate-parameters-and-fail-fast' is defined as string, but the parent template
defines it as securestring). Line: 1427, Column: 14

 [-] Parameter Types Should Be Consistent (2257 ms) 
##[error]        Type Mismatch: Parameter 'vnetForApplicationGateway' in nested template 'vnet-application-gateway' is defined as object, but the parent template defines it as secureObject). Line: 2444, Column: 22
##[error]        Type Mismatch: Parameter 'appgwSSLBackendRootCertData' in nested template 'application-gateway-deployment' is defined as securestring, but the parent template defines it as string). Line: 1986, Column: 14
##[error]        Type Mismatch: Parameter 'sslCertData' in nested template 'application-gateway-deployment' is defined as securestring, but the parent template defines it as string). Line: 2022, Column: 14
##[error]        Type Mismatch: Parameter 'vnetForApplicationGateway' in nested template 'application-gateway-deployment' is defined as secureObject, but the parent template defines it as object). Line: 2034, Column: 14