### PR TITLE
edburns/o-777-update-it-readme

### DIFF
--- a/.github/it/README.md
+++ b/.github/it/README.md
@@ -209,6 +209,8 @@ Before using the IT validation system, ensure:
       ```
 
    Both scripts require that you have already run `az login`, `gh auth login`, and have `yq` 4.x installed. The scripts will set the required GitHub repository secrets automatically.
+   
+- [ ] If you are setting up a new Azure subscription to run the tests, see [Trouble Shooting](#some-notes-on-preparing-a-new-azure-subscription-to-run-the-tests).
 
 - [ ] Access to the `it` branch for report storage
 

--- a/README.md
+++ b/README.md
@@ -19,6 +19,8 @@ Please refer to the README for [documentation on WebLogic Server running on an A
 
 Please refer to the README for [documentation on WebLogic Server running on an Azure Virtual Machine](https://docs.oracle.com/en/middleware/standalone/weblogic-server/wlazu/get-started-oracle-weblogic-server-microsoft-azure-iaas.html#GUID-E0B24A45-F496-4509-858E-103F5EBF67A7)
 
+Please refer to the README for [documentation about how to run the CI/CD](.github/it/README.md).
+
 ## Local Build Setup and Requirements
 
 This project utilizes [GitHub Packages](https://github.com/features/packages) for hosting and retrieving some dependencies. To ensure you can smoothly run and build the project in your local environment, specific configuration settings are required.


### PR DESCRIPTION
modified:   .github/it/README.md
modified:   README.md

### Prompt

I am updating `.github/it/README.md` to ensure it matches the current state of the codebase. In particular, I want to ensure that the `Prerequisites` section has enough information that a human user can configure their GitHub Actions secrets for their repository such that the workflows documented in `.github/it/README.md` can successfully run, assuming there are no bugs in the workflows.

I am aware that the current state of the `Prerequisites` is out of date. For example, 

- I see no mention of the need to edit `credentials-params-wls-vm.yaml` or `credentials-params-wls-aks.yaml`
- I see no mention of the fact that there are two different setup scripts, one for VM and one for AKS. `setup-for-wls-vm.sh` and `setup-for-wls-aks.sh` respectively. In fact the script mentioned in the `.github/it/README.md` appears not to exist. 

Update the `Prerequisites` section to fix these problems.

### Prompt

I want to append a section to the `Troubleshooting` section in `.github/it/README.md` titled `Some notes on preparing a new Azure subscription to run the tests`.

The entire point of the last 9 commits was twofold.

1. Update the offers and corresponding workflows that test the offers so the workflows successfully pass and exercise a state of the offers that runs with the provided test Azure subscription.

2. Discover and resolve any issues regarding preparing the test subscription itself.

Analyze the last 9 commits and derive the lessons that someone who is configuring a net-new Azure subscription to run the tests would find essential to know. Describe these lessons in the new section in `.github/it/README.md`.

✅ make sure to get all the scripts I created to register providers, and that sort of thing
✅ call out region specific lessons.
